### PR TITLE
Expand add_target tool to support all 25 PBXProductType cases

### DIFF
--- a/Sources/XcodeProjectMCP/AddTargetTool.swift
+++ b/Sources/XcodeProjectMCP/AddTargetTool.swift
@@ -27,7 +27,7 @@ public struct AddTargetTool: Sendable {
                     ]),
                     "product_type": .object([
                         "type": .string("string"),
-                        "description": .string("Product type (app, framework, staticLibrary, dynamicLibrary, unitTestBundle, uiTestBundle)")
+                        "description": .string("Product type (application, framework, staticFramework, xcFramework, dynamicLibrary, staticLibrary, bundle, unitTestBundle, uiTestBundle, appExtension, extensionKitExtension, commandLineTool, watchApp, watch2App, watch2AppContainer, watchExtension, watch2Extension, tvExtension, messagesApplication, messagesExtension, stickerPack, xpcService, ocUnitTestBundle, xcodeExtension, instrumentsPackage, intentsServiceExtension, onDemandInstallCapableApplication, metalLibrary, driverExtension, systemExtension)")
                     ]),
                     "bundle_identifier": .object([
                         "type": .string("string"),
@@ -72,18 +72,66 @@ public struct AddTargetTool: Sendable {
         // Map product type string to PBXProductType
         let productType: PBXProductType
         switch productTypeString.lowercased() {
-        case "app", "application":
+        case "application", "app":
             productType = .application
         case "framework":
             productType = .framework
-        case "staticlibrary", "static_library":
-            productType = .staticLibrary
+        case "staticframework", "static_framework":
+            productType = .staticFramework
+        case "xcframework", "xc_framework":
+            productType = .xcFramework
         case "dynamiclibrary", "dynamic_library":
             productType = .dynamicLibrary
+        case "staticlibrary", "static_library":
+            productType = .staticLibrary
+        case "bundle":
+            productType = .bundle
         case "unittestbundle", "unit_test_bundle":
             productType = .unitTestBundle
         case "uitestbundle", "ui_test_bundle":
             productType = .uiTestBundle
+        case "appextension", "app_extension":
+            productType = .appExtension
+        case "extensionkitextension", "extensionkit_extension":
+            productType = .extensionKitExtension
+        case "commandlinetool", "command_line_tool":
+            productType = .commandLineTool
+        case "watchapp", "watch_app":
+            productType = .watchApp
+        case "watch2app", "watch2_app", "watch_2_app":
+            productType = .watch2App
+        case "watch2appcontainer", "watch2_app_container", "watch_2_app_container":
+            productType = .watch2AppContainer
+        case "watchextension", "watch_extension":
+            productType = .watchExtension
+        case "watch2extension", "watch2_extension", "watch_2_extension":
+            productType = .watch2Extension
+        case "tvextension", "tv_extension":
+            productType = .tvExtension
+        case "messagesapplication", "messages_application":
+            productType = .messagesApplication
+        case "messagesextension", "messages_extension":
+            productType = .messagesExtension
+        case "stickerpack", "sticker_pack":
+            productType = .stickerPack
+        case "xpcservice", "xpc_service":
+            productType = .xpcService
+        case "ocunittestbundle", "oc_unit_test_bundle":
+            productType = .ocUnitTestBundle
+        case "xcodeextension", "xcode_extension":
+            productType = .xcodeExtension
+        case "instrumentspackage", "instruments_package":
+            productType = .instrumentsPackage
+        case "intentsserviceextension", "intents_service_extension":
+            productType = .intentsServiceExtension
+        case "ondemandinstallcapableapplication", "on_demand_install_capable_application":
+            productType = .onDemandInstallCapableApplication
+        case "metallibrary", "metal_library":
+            productType = .metalLibrary
+        case "driverextension", "driver_extension":
+            productType = .driverExtension
+        case "systemextension", "system_extension":
+            productType = .systemExtension
         default:
             throw MCPError.invalidParams("Invalid product type: \(productTypeString)")
         }
@@ -191,17 +239,31 @@ public struct AddTargetTool: Sendable {
 extension PBXProductType {
     var fileExtension: String? {
         switch self {
-        case .application:
+        case .application, .watchApp, .watch2App, .watch2AppContainer, .messagesApplication, .onDemandInstallCapableApplication:
             return "app"
-        case .framework:
+        case .framework, .staticFramework:
             return "framework"
+        case .xcFramework:
+            return "xcframework"
         case .staticLibrary:
             return "a"
         case .dynamicLibrary:
             return "dylib"
-        case .unitTestBundle, .uiTestBundle:
+        case .bundle:
+            return "bundle"
+        case .unitTestBundle, .uiTestBundle, .ocUnitTestBundle:
             return "xctest"
-        default:
+        case .appExtension, .extensionKitExtension, .watchExtension, .watch2Extension, .tvExtension, .messagesExtension, .stickerPack, .xcodeExtension, .intentsServiceExtension, .driverExtension, .systemExtension:
+            return "appex"
+        case .commandLineTool:
+            return nil
+        case .xpcService:
+            return "xpc"
+        case .instrumentsPackage:
+            return "instrdst"
+        case .metalLibrary:
+            return "metallib"
+        case .none:
             return nil
         }
     }

--- a/Tests/XcodeProjectMCPTests/AddTargetToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddTargetToolTests.swift
@@ -246,4 +246,238 @@ struct AddTargetToolTests {
             try tool.execute(arguments: args)
         }
     }
+    
+    @Test("Add static framework target")
+    func addStaticFrameworkTarget() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        
+        let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
+        
+        let tool = AddTargetTool(pathUtility: PathUtility(basePath: tempDir.path))
+        let args: [String: Value] = [
+            "project_path": Value.string(projectPath.string),
+            "target_name": Value.string("StaticFramework"),
+            "product_type": Value.string("staticFramework"),
+            "bundle_identifier": Value.string("com.test.staticframework")
+        ]
+        
+        let result = try tool.execute(arguments: args)
+        
+        guard case let .text(message) = result.content.first else {
+            Issue.record("Expected text result")
+            return
+        }
+        #expect(message.contains("Successfully created target 'StaticFramework'"))
+        
+        let xcodeproj = try XcodeProj(path: projectPath)
+        let target = xcodeproj.pbxproj.nativeTargets.first { $0.name == "StaticFramework" }
+        #expect(target?.productType == .staticFramework)
+    }
+    
+    @Test("Add XCFramework target")
+    func addXCFrameworkTarget() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        
+        let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
+        
+        let tool = AddTargetTool(pathUtility: PathUtility(basePath: tempDir.path))
+        let args: [String: Value] = [
+            "project_path": Value.string(projectPath.string),
+            "target_name": Value.string("MyXCFramework"),
+            "product_type": Value.string("xcFramework"),
+            "bundle_identifier": Value.string("com.test.xcframework")
+        ]
+        
+        let result = try tool.execute(arguments: args)
+        
+        guard case let .text(message) = result.content.first else {
+            Issue.record("Expected text result")
+            return
+        }
+        #expect(message.contains("Successfully created target 'MyXCFramework'"))
+        
+        let xcodeproj = try XcodeProj(path: projectPath)
+        let target = xcodeproj.pbxproj.nativeTargets.first { $0.name == "MyXCFramework" }
+        #expect(target?.productType == .xcFramework)
+    }
+    
+    @Test("Add app extension target")
+    func addAppExtensionTarget() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        
+        let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
+        
+        let tool = AddTargetTool(pathUtility: PathUtility(basePath: tempDir.path))
+        let args: [String: Value] = [
+            "project_path": Value.string(projectPath.string),
+            "target_name": Value.string("MyExtension"),
+            "product_type": Value.string("appExtension"),
+            "bundle_identifier": Value.string("com.test.extension")
+        ]
+        
+        let result = try tool.execute(arguments: args)
+        
+        guard case let .text(message) = result.content.first else {
+            Issue.record("Expected text result")
+            return
+        }
+        #expect(message.contains("Successfully created target 'MyExtension'"))
+        
+        let xcodeproj = try XcodeProj(path: projectPath)
+        let target = xcodeproj.pbxproj.nativeTargets.first { $0.name == "MyExtension" }
+        #expect(target?.productType == .appExtension)
+    }
+    
+    @Test("Add command line tool target")
+    func addCommandLineToolTarget() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        
+        let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
+        
+        let tool = AddTargetTool(pathUtility: PathUtility(basePath: tempDir.path))
+        let args: [String: Value] = [
+            "project_path": Value.string(projectPath.string),
+            "target_name": Value.string("MyTool"),
+            "product_type": Value.string("commandLineTool"),
+            "bundle_identifier": Value.string("com.test.tool"),
+            "platform": Value.string("macOS")
+        ]
+        
+        let result = try tool.execute(arguments: args)
+        
+        guard case let .text(message) = result.content.first else {
+            Issue.record("Expected text result")
+            return
+        }
+        #expect(message.contains("Successfully created target 'MyTool'"))
+        
+        let xcodeproj = try XcodeProj(path: projectPath)
+        let target = xcodeproj.pbxproj.nativeTargets.first { $0.name == "MyTool" }
+        #expect(target?.productType == .commandLineTool)
+    }
+    
+    @Test("Add watch app target")
+    func addWatchAppTarget() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        
+        let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
+        
+        let tool = AddTargetTool(pathUtility: PathUtility(basePath: tempDir.path))
+        let args: [String: Value] = [
+            "project_path": Value.string(projectPath.string),
+            "target_name": Value.string("MyWatchApp"),
+            "product_type": Value.string("watchApp"),
+            "bundle_identifier": Value.string("com.test.watchapp"),
+            "platform": Value.string("watchOS")
+        ]
+        
+        let result = try tool.execute(arguments: args)
+        
+        guard case let .text(message) = result.content.first else {
+            Issue.record("Expected text result")
+            return
+        }
+        #expect(message.contains("Successfully created target 'MyWatchApp'"))
+        
+        let xcodeproj = try XcodeProj(path: projectPath)
+        let target = xcodeproj.pbxproj.nativeTargets.first { $0.name == "MyWatchApp" }
+        #expect(target?.productType == .watchApp)
+    }
+    
+    @Test("Add messages extension target")
+    func addMessagesExtensionTarget() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        
+        let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
+        
+        let tool = AddTargetTool(pathUtility: PathUtility(basePath: tempDir.path))
+        let args: [String: Value] = [
+            "project_path": Value.string(projectPath.string),
+            "target_name": Value.string("MyMessagesExtension"),
+            "product_type": Value.string("messagesExtension"),
+            "bundle_identifier": Value.string("com.test.messagesextension")
+        ]
+        
+        let result = try tool.execute(arguments: args)
+        
+        guard case let .text(message) = result.content.first else {
+            Issue.record("Expected text result")
+            return
+        }
+        #expect(message.contains("Successfully created target 'MyMessagesExtension'"))
+        
+        let xcodeproj = try XcodeProj(path: projectPath)
+        let target = xcodeproj.pbxproj.nativeTargets.first { $0.name == "MyMessagesExtension" }
+        #expect(target?.productType == .messagesExtension)
+    }
+    
+    @Test("Add xpc service target")
+    func addXPCServiceTarget() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+        
+        let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
+        
+        let tool = AddTargetTool(pathUtility: PathUtility(basePath: tempDir.path))
+        let args: [String: Value] = [
+            "project_path": Value.string(projectPath.string),
+            "target_name": Value.string("MyXPCService"),
+            "product_type": Value.string("xpcService"),
+            "bundle_identifier": Value.string("com.test.xpcservice"),
+            "platform": Value.string("macOS")
+        ]
+        
+        let result = try tool.execute(arguments: args)
+        
+        guard case let .text(message) = result.content.first else {
+            Issue.record("Expected text result")
+            return
+        }
+        #expect(message.contains("Successfully created target 'MyXPCService'"))
+        
+        let xcodeproj = try XcodeProj(path: projectPath)
+        let target = xcodeproj.pbxproj.nativeTargets.first { $0.name == "MyXPCService" }
+        #expect(target?.productType == .xpcService)
+    }
 }


### PR DESCRIPTION
- Add support for all product types from XcodeProj library
- Update product type mapping from 6 to 25 types
- Include new types: staticFramework, xcFramework, appExtension, commandLineTool, watchApp, messagesExtension, xpcService, etc.
- Update file extension mapping for all product types
- Add comprehensive tests for new product types

🤖 Generated with [Claude Code](https://claude.ai/code)