### PR TITLE
Use stderr for logging

### DIFF
--- a/Sources/xcodeproj-mcp-server/run-server.swift
+++ b/Sources/xcodeproj-mcp-server/run-server.swift
@@ -6,7 +6,7 @@ import XcodeProjectMCP
 struct XcodeprojMCPServer {
     static func main() async throws {
         LoggingSystem.bootstrap { label in
-            var handler = StreamLogHandler.standardOutput(label: label)
+            var handler = StreamLogHandler.standardError(label: label)
             handler.logLevel = .debug
             return handler
         }


### PR DESCRIPTION
I found some MCP clients (such as gemini-cli, mcp-inspector) warn when receive non-JSON message from stdout.
To fix it, send log to stderr.

## Example

### mcp-inspector

```console
$ npx @modelcontextprotocol/inspector \
docker run --rm -i -v $PWD:/workspace ghcr.io/giginet/xcodeproj-mcp-server /workspace
Starting MCP inspector...
⚙️ Proxy server listening on 127.0.0.1:6277
(omitted)
Received POST message for sessionId 27ce2392-8499-4d54-a413-213fac7899bf
Error from MCP server: SyntaxError: Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)
    at JSON.parse (<anonymous>)
    at deserializeMessage (file:///Users/user/.npm/_npx/5a9d879542beca3a/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js:26:44)
    at ReadBuffer.readMessage (file:///Users/user/.npm/_npx/5a9d879542beca3a/node_modules/@modelcontextprotocol/sdk/dist/esm/shared/stdio.js:19:16)
    at StdioClientTransport.processReadBuffer (file:///Users/user/.npm/_npx/5a9d879542beca3a/node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js:127:50)
    at Socket.<anonymous> (file:///Users/user/.npm/_npx/5a9d879542beca3a/node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js:98:22)
    at Socket.emit (node:events:518:28)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
    at Readable.push (node:internal/streams/readable:392:5)
    at Pipe.onStreamRead (node:internal/stream_base_commons:189:23)
```

### gemini-cli

<img width="846" alt="image" src="https://github.com/user-attachments/assets/de31415d-4be8-4456-a683-e5c06052a092" />

my setting:

```js
{
  ...
  "mcpServers": {
    "xcodeproj": {
      "command": "docker",
      "args": [
        "run",
        "-i",
        "--rm",
        "-v",
        "${PWD}:/workspace",
        "ghcr.io/giginet/xcodeproj-mcp-server",
        "/workspace"
      ]
    }
  }
}
```

```console
$ gemini
MCP ERROR (xcodeproj): SyntaxError: Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)
MCP ERROR (xcodeproj): SyntaxError: Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)
MCP ERROR (xcodeproj): SyntaxError: Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)
MCP ERROR (xcodeproj): SyntaxError: Unexpected non-whitespace character after JSON at position 4 (line 1 column 5)
using macos seatbelt (profile: permissive-open) ...
(omitted)
```