### PR TITLE
add_file: support path-based group

### DIFF
--- a/Sources/XcodeProjectMCP/AddFileTool.swift
+++ b/Sources/XcodeProjectMCP/AddFileTool.swift
@@ -90,8 +90,9 @@ public struct AddFileTool: Sendable {
             let targetGroup: PBXGroup
             if let groupName = groupName {
                 // Find group by name or path
-                if let foundGroup = xcodeproj.pbxproj.groups.first(where: { $0.name == groupName || $0.path == groupName })
-                {
+                if let foundGroup = xcodeproj.pbxproj.groups.first(where: {
+                    $0.name == groupName || $0.path == groupName
+                }) {
                     targetGroup = foundGroup
                 } else {
                     throw MCPError.invalidParams("Group '\(groupName)' not found in project")

--- a/Sources/XcodeProjectMCP/AddFileTool.swift
+++ b/Sources/XcodeProjectMCP/AddFileTool.swift
@@ -89,8 +89,8 @@ public struct AddFileTool: Sendable {
             // Find the group to add the file to
             let targetGroup: PBXGroup
             if let groupName = groupName {
-                // Find group by name
-                if let foundGroup = xcodeproj.pbxproj.groups.first(where: { $0.name == groupName })
+                // Find group by name or path
+                if let foundGroup = xcodeproj.pbxproj.groups.first(where: { $0.name == groupName || $0.path == groupName })
                 {
                     targetGroup = foundGroup
                 } else {

--- a/Tests/XcodeProjectMCPTests/TestProjectHelper.swift
+++ b/Tests/XcodeProjectMCPTests/TestProjectHelper.swift
@@ -13,6 +13,8 @@ struct TestProjectHelper {
         pbxproj.add(object: mainGroup)
         let productsGroup = PBXGroup(children: [], sourceTree: .group, name: "Products")
         pbxproj.add(object: productsGroup)
+        let testsGroup = PBXGroup(children: [], sourceTree: .group, path: "Tests")
+        pbxproj.add(object: testsGroup)
 
         // Create build configurations
         let debugConfig = XCBuildConfiguration(name: "Debug", buildSettings: [:])


### PR DESCRIPTION
Support path-based group for group_name argument of add_file tool.

I found `add_file` tool fails to add a file to specified group which like `XXXTests`.

While testing with new simple xcodeproj, I found it seems xcodeproj has several type of groups.
https://github.com/mtgto/ExampleAddFile/blob/main/run.swift

I found three kinds of groups in my xcodeproj:

- Group has name && has no path
  - `Products`
- Groups have no name && have path
  - `ExampleAddFile`
  - `ExampleAddFileUITests`
  - `ExampleAddFileTests`
- Group have no name and path (WTF?)

<img width="667" alt="image" src="https://github.com/user-attachments/assets/78f45ab4-737d-4143-8d26-b3c4fa5a10f3" />

`tuist/xcodeproj` says there are 6 groups:

```
Group: name=Optional("Products"), path=nil
Group: name=nil, path=Optional("SubFolder")
Group: name=nil, path=Optional("ExampleAddFile")
Group: name=nil, path=nil
Group: name=nil, path=Optional("ExampleAddFileUITests")
Group: name=nil, path=Optional("ExampleAddFileTests")
```