### PR TITLE
Add add_folder tool for Xcode project folder references

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This server enables AI assistants and other MCP clients to:
 
 ### Development Workflow Automation
 - **Add new files to targets**: After creating a new Swift file, automatically add it to the appropriate target's source files for compilation
+- **Add folder references**: Include external resource folders or asset directories as synchronized folder references in your project, automatically reflecting any file system changes
 - **Add build phases**: Integrate code formatters, linters, or custom build scripts into your targets (e.g., SwiftLint, SwiftFormat execution phases)
 - **Create frameworks and app extensions**: Quickly scaffold new framework targets or app extensions for modularizing your codebase
 
@@ -128,6 +129,9 @@ This is especially useful when running the server in Docker containers or other 
 
 - **`move_file`** - Move or rename a file within the project
   - Parameters: `project_path`, `source_path`, `destination_path`
+
+- **`add_folder`** - Add a folder reference to the project
+  - Parameters: `project_path`, `folder_path`, `group_name`, `target_name`
 
 - **`create_group`** - Create a new group in the project navigator
   - Parameters: `project_path`, `group_name`, `parent_group_path`

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ This is especially useful when running the server in Docker containers or other 
 - **`move_file`** - Move or rename a file within the project
   - Parameters: `project_path`, `source_path`, `destination_path`
 
-- **`add_folder`** - Add a folder reference to the project
+- **`add_synchronized_folder`** - Add a synchronized folder reference to the project
   - Parameters: `project_path`, `folder_path`, `group_name`, `target_name`
 
 - **`create_group`** - Create a new group in the project navigator

--- a/Sources/XcodeProjectMCP/AddFolderTool.swift
+++ b/Sources/XcodeProjectMCP/AddFolderTool.swift
@@ -1,0 +1,171 @@
+import Foundation
+import MCP
+import PathKit
+import XcodeProj
+
+public struct AddFolderTool: Sendable {
+    private let pathUtility: PathUtility
+
+    public init(pathUtility: PathUtility) {
+        self.pathUtility = pathUtility
+    }
+
+    public func tool() -> Tool {
+        Tool(
+            name: "add_folder",
+            description: "Add a folder reference to an Xcode project",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "project_path": .object([
+                        "type": .string("string"),
+                        "description": .string(
+                            "Path to the .xcodeproj file (relative to current directory)"),
+                    ]),
+                    "folder_path": .object([
+                        "type": .string("string"),
+                        "description": .string(
+                            "Path to the folder to add (relative to project root or absolute)"),
+                    ]),
+                    "group_name": .object([
+                        "type": .string("string"),
+                        "description": .string(
+                            "Name of the group to add the folder to (optional, defaults to main group)"
+                        ),
+                    ]),
+                    "target_name": .object([
+                        "type": .string("string"),
+                        "description": .string(
+                            "Name of the target to add the folder to (optional)"),
+                    ]),
+                ]),
+                "required": .array([.string("project_path"), .string("folder_path")]),
+            ])
+        )
+    }
+
+    public func execute(arguments: [String: Value]) throws -> CallTool.Result {
+        guard case let .string(projectPath) = arguments["project_path"],
+            case let .string(folderPath) = arguments["folder_path"]
+        else {
+            throw MCPError.invalidParams("project_path and folder_path are required")
+        }
+
+        let groupName: String?
+        if case let .string(group) = arguments["group_name"] {
+            groupName = group
+        } else {
+            groupName = nil
+        }
+
+        let targetName: String?
+        if case let .string(target) = arguments["target_name"] {
+            targetName = target
+        } else {
+            targetName = nil
+        }
+
+        do {
+            // Resolve and validate the project path
+            let resolvedProjectPath = try pathUtility.resolvePath(from: projectPath)
+            let projectURL = URL(filePath: resolvedProjectPath)
+
+            // Resolve and validate the folder path
+            let resolvedFolderPath = try pathUtility.resolvePath(from: folderPath)
+
+            // Verify that the path is actually a directory
+            var isDirectory: ObjCBool = false
+            if !FileManager.default.fileExists(
+                atPath: resolvedFolderPath, isDirectory: &isDirectory)
+            {
+                throw MCPError.invalidParams("Folder does not exist at path: \(folderPath)")
+            }
+            if !isDirectory.boolValue {
+                throw MCPError.invalidParams("Path is not a directory: \(folderPath)")
+            }
+
+            let xcodeproj = try XcodeProj(path: Path(projectURL.path))
+
+            // Create file system synchronized root group
+            let folderName = URL(filePath: resolvedFolderPath).lastPathComponent
+            // Use relative path from project for folder reference
+            let relativePath =
+                pathUtility.makeRelativePath(from: resolvedFolderPath) ?? resolvedFolderPath
+
+            let folderReference = PBXFileSystemSynchronizedRootGroup(
+                sourceTree: .group,
+                path: relativePath,
+                name: folderName
+            )
+            xcodeproj.pbxproj.add(object: folderReference)
+
+            // Find the group to add the folder to
+            let targetGroup: PBXGroup
+            if let groupName = groupName {
+                // Find group by name or path
+                if let foundGroup = xcodeproj.pbxproj.groups.first(where: {
+                    $0.name == groupName || $0.path == groupName
+                }) {
+                    targetGroup = foundGroup
+                } else {
+                    throw MCPError.invalidParams("Group '\(groupName)' not found in project")
+                }
+            } else {
+                // Use main group
+                guard let project = try xcodeproj.pbxproj.rootProject(),
+                    let mainGroup = project.mainGroup
+                else {
+                    throw MCPError.internalError("Main group not found in project")
+                }
+                targetGroup = mainGroup
+            }
+
+            // Add folder to group
+            targetGroup.children.append(folderReference)
+
+            // Add folder to target if specified
+            if let targetName = targetName {
+                guard
+                    let target = xcodeproj.pbxproj.nativeTargets.first(where: {
+                        $0.name == targetName
+                    })
+                else {
+                    throw MCPError.invalidParams("Target '\(targetName)' not found in project")
+                }
+
+                // Create build file for the folder
+                let buildFile = PBXBuildFile(file: folderReference)
+                xcodeproj.pbxproj.add(object: buildFile)
+
+                // Add to resources build phase
+                if let resourcesBuildPhase = target.buildPhases.first(where: {
+                    $0 is PBXResourcesBuildPhase
+                }) as? PBXResourcesBuildPhase {
+                    resourcesBuildPhase.files?.append(buildFile)
+                } else {
+                    // Create resources build phase if it doesn't exist
+                    let resourcesBuildPhase = PBXResourcesBuildPhase(files: [buildFile])
+                    xcodeproj.pbxproj.add(object: resourcesBuildPhase)
+                    target.buildPhases.append(resourcesBuildPhase)
+                }
+            }
+
+            // Write project
+            try xcodeproj.write(path: Path(projectURL.path))
+
+            let targetInfo = targetName != nil ? " to target '\(targetName!)'" : ""
+            let groupInfo = groupName != nil ? " in group '\(groupName!)'" : ""
+
+            return CallTool.Result(
+                content: [
+                    .text(
+                        "Successfully added folder reference '\(folderName)'\(targetInfo)\(groupInfo)"
+                    )
+                ]
+            )
+        } catch {
+            throw MCPError.internalError(
+                "Failed to add folder to Xcode project: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Sources/XcodeProjectMCP/AddFolderTool.swift
+++ b/Sources/XcodeProjectMCP/AddFolderTool.swift
@@ -12,8 +12,8 @@ public struct AddFolderTool: Sendable {
 
     public func tool() -> Tool {
         Tool(
-            name: "add_folder",
-            description: "Add a folder reference to an Xcode project",
+            name: "add_synchronized_folder",
+            description: "Add a synchronized folder reference to an Xcode project",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([

--- a/Sources/XcodeProjectMCP/XcodeProjectMCPServer.swift
+++ b/Sources/XcodeProjectMCP/XcodeProjectMCPServer.swift
@@ -23,6 +23,7 @@ public enum ToolName: String, CaseIterable {
     case listSwiftPackages = "list_swift_packages"
     case removeSwiftPackage = "remove_swift_package"
     case listGroups = "list_groups"
+    case addFolder = "add_folder"
 }
 
 public struct XcodeProjectMCPServer {
@@ -61,6 +62,7 @@ public struct XcodeProjectMCPServer {
         let listSwiftPackagesTool = ListSwiftPackagesTool(pathUtility: pathUtility)
         let removeSwiftPackageTool = RemoveSwiftPackageTool(pathUtility: pathUtility)
         let listGroupsTool = ListGroupsTool(pathUtility: pathUtility)
+        let addFolderTool = AddFolderTool(pathUtility: pathUtility)
 
         // Register tools/list handler
         await server.withMethodHandler(ListTools.self) { _ in
@@ -85,6 +87,7 @@ public struct XcodeProjectMCPServer {
                 listSwiftPackagesTool.tool(),
                 removeSwiftPackageTool.tool(),
                 listGroupsTool.tool(),
+                addFolderTool.tool(),
             ])
         }
 
@@ -135,6 +138,8 @@ public struct XcodeProjectMCPServer {
                 return try removeSwiftPackageTool.execute(arguments: params.arguments ?? [:])
             case .listGroups:
                 return try listGroupsTool.execute(arguments: params.arguments ?? [:])
+            case .addFolder:
+                return try addFolderTool.execute(arguments: params.arguments ?? [:])
             }
         }
 

--- a/Sources/XcodeProjectMCP/XcodeProjectMCPServer.swift
+++ b/Sources/XcodeProjectMCP/XcodeProjectMCPServer.swift
@@ -23,7 +23,7 @@ public enum ToolName: String, CaseIterable {
     case listSwiftPackages = "list_swift_packages"
     case removeSwiftPackage = "remove_swift_package"
     case listGroups = "list_groups"
-    case addFolder = "add_folder"
+    case addSynchronizedFolder = "add_synchronized_folder"
 }
 
 public struct XcodeProjectMCPServer {
@@ -62,7 +62,7 @@ public struct XcodeProjectMCPServer {
         let listSwiftPackagesTool = ListSwiftPackagesTool(pathUtility: pathUtility)
         let removeSwiftPackageTool = RemoveSwiftPackageTool(pathUtility: pathUtility)
         let listGroupsTool = ListGroupsTool(pathUtility: pathUtility)
-        let addFolderTool = AddFolderTool(pathUtility: pathUtility)
+        let addSynchronizedFolderTool = AddFolderTool(pathUtility: pathUtility)
 
         // Register tools/list handler
         await server.withMethodHandler(ListTools.self) { _ in
@@ -87,7 +87,7 @@ public struct XcodeProjectMCPServer {
                 listSwiftPackagesTool.tool(),
                 removeSwiftPackageTool.tool(),
                 listGroupsTool.tool(),
-                addFolderTool.tool(),
+                addSynchronizedFolderTool.tool(),
             ])
         }
 
@@ -138,8 +138,8 @@ public struct XcodeProjectMCPServer {
                 return try removeSwiftPackageTool.execute(arguments: params.arguments ?? [:])
             case .listGroups:
                 return try listGroupsTool.execute(arguments: params.arguments ?? [:])
-            case .addFolder:
-                return try addFolderTool.execute(arguments: params.arguments ?? [:])
+            case .addSynchronizedFolder:
+                return try addSynchronizedFolderTool.execute(arguments: params.arguments ?? [:])
             }
         }
 

--- a/Tests/XcodeProjectMCPTests/AddFolderToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddFolderToolTests.swift
@@ -11,7 +11,10 @@ struct AddFolderToolTests {
     let pathUtility: PathUtility
 
     init() {
-        self.tempDir = NSTemporaryDirectory() + "AddFolderToolTests-\(UUID().uuidString)/"
+        self.tempDir =
+            FileManager.default.temporaryDirectory
+            .appendingPathComponent("AddFolderToolTests-\(UUID().uuidString)")
+            .path
         self.pathUtility = PathUtility(basePath: tempDir)
         try? FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
     }

--- a/Tests/XcodeProjectMCPTests/AddFolderToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddFolderToolTests.swift
@@ -1,0 +1,223 @@
+import Foundation
+import MCP
+import PathKit
+import Testing
+import XcodeProj
+
+@testable import XcodeProjectMCP
+
+struct AddFolderToolTests {
+    let tempDir: String
+    let pathUtility: PathUtility
+
+    init() {
+        self.tempDir = NSTemporaryDirectory() + "AddFolderToolTests-\(UUID().uuidString)/"
+        self.pathUtility = PathUtility(basePath: tempDir)
+        try? FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+    }
+
+    @Test("Tool has correct properties")
+    func toolProperties() {
+        let tool = AddFolderTool(pathUtility: pathUtility)
+
+        #expect(tool.tool().name == "add_folder")
+        #expect(tool.tool().description == "Add a folder reference to an Xcode project")
+
+        let schema = tool.tool().inputSchema
+        if case let .object(schemaDict) = schema {
+            if case let .object(props) = schemaDict["properties"] {
+                #expect(props["project_path"] != nil)
+                #expect(props["folder_path"] != nil)
+                #expect(props["group_name"] != nil)
+                #expect(props["target_name"] != nil)
+            }
+
+            if case let .array(required) = schemaDict["required"] {
+                #expect(required.count == 2)
+                #expect(required.contains(.string("project_path")))
+                #expect(required.contains(.string("folder_path")))
+            }
+        }
+    }
+
+    @Test("Validates required parameters")
+    func validateRequiredParameters() throws {
+        let tool = AddFolderTool(pathUtility: pathUtility)
+
+        // Missing project_path
+        #expect(throws: MCPError.self) {
+            try tool.execute(arguments: ["folder_path": .string("path/to/folder")])
+        }
+
+        // Missing folder_path
+        #expect(throws: MCPError.self) {
+            try tool.execute(arguments: ["project_path": .string("project.xcodeproj")])
+        }
+
+        // Invalid parameter types
+        #expect(throws: MCPError.self) {
+            try tool.execute(arguments: [
+                "project_path": Value.bool(true),
+                "folder_path": Value.string("path/to/folder"),
+            ])
+        }
+    }
+
+    @Test("Adds folder reference to project")
+    func addsFolderToProject() throws {
+        let tool = AddFolderTool(pathUtility: pathUtility)
+
+        // Create a test project
+        let projectPath = Path(tempDir) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
+
+        // Create a test folder
+        let folderPath = Path(tempDir) + "TestFolder"
+        try FileManager.default.createDirectory(
+            atPath: folderPath.string, withIntermediateDirectories: true)
+
+        // Execute the tool
+        let result = try tool.execute(arguments: [
+            "project_path": .string(projectPath.string),
+            "folder_path": .string(folderPath.string),
+        ])
+
+        // Verify the result
+        if case let .text(message) = result.content.first {
+            #expect(message.contains("Successfully added folder reference 'TestFolder'"))
+        } else {
+            Issue.record("Expected text result")
+        }
+
+        // Verify the project was updated
+        let updatedProject = try XcodeProj(path: projectPath)
+        let folderReferences = updatedProject.pbxproj.fileSystemSynchronizedRootGroups
+        #expect(folderReferences.count == 1)
+        #expect(folderReferences.first?.name == "TestFolder")
+    }
+
+    @Test("Adds folder to specific group")
+    func addsFolderToSpecificGroup() throws {
+        let tool = AddFolderTool(pathUtility: pathUtility)
+
+        // Create a test project
+        let projectPath = Path(tempDir) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
+
+        // Load the project and add a custom group
+        let xcodeproj = try XcodeProj(path: projectPath)
+        let customGroup = PBXGroup(children: [], sourceTree: .group, name: "CustomGroup")
+        xcodeproj.pbxproj.add(object: customGroup)
+        if let mainGroup = try xcodeproj.pbxproj.rootProject()?.mainGroup {
+            mainGroup.children.append(customGroup)
+        }
+        try xcodeproj.write(path: projectPath)
+
+        // Create a test folder
+        let folderPath = Path(tempDir) + "TestFolder"
+        try FileManager.default.createDirectory(
+            atPath: folderPath.string, withIntermediateDirectories: true)
+
+        // Execute the tool
+        let result = try tool.execute(arguments: [
+            "project_path": .string(projectPath.string),
+            "folder_path": .string(folderPath.string),
+            "group_name": .string("CustomGroup"),
+        ])
+
+        // Verify the result
+        if case let .text(message) = result.content.first {
+            #expect(message.contains("Successfully added folder reference 'TestFolder'"))
+            #expect(message.contains("in group 'CustomGroup'"))
+        } else {
+            Issue.record("Expected text result")
+        }
+
+        // Verify the folder was added to the correct group
+        let updatedProject = try XcodeProj(path: projectPath)
+        let updatedCustomGroup = updatedProject.pbxproj.groups.first { $0.name == "CustomGroup" }
+        #expect(updatedCustomGroup?.children.count == 1)
+    }
+
+    @Test("Adds folder to target")
+    func addsFolderToTarget() throws {
+        let tool = AddFolderTool(pathUtility: pathUtility)
+
+        // Create a test project with a target
+        let projectPath = Path(tempDir) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProjectWithTarget(
+            name: "TestProject", targetName: "TestTarget", at: projectPath)
+
+        // Create a test folder
+        let folderPath = Path(tempDir) + "TestFolder"
+        try FileManager.default.createDirectory(
+            atPath: folderPath.string, withIntermediateDirectories: true)
+
+        // Execute the tool
+        let result = try tool.execute(arguments: [
+            "project_path": Value.string(projectPath.string),
+            "folder_path": Value.string(folderPath.string),
+            "target_name": Value.string("TestTarget"),
+        ])
+
+        // Verify the result
+        if case let .text(message) = result.content.first {
+            #expect(message.contains("Successfully added folder reference 'TestFolder'"))
+            #expect(message.contains("to target 'TestTarget'"))
+        } else {
+            Issue.record("Expected text result")
+        }
+
+        // Verify the folder was added to the target
+        let updatedProject = try XcodeProj(path: projectPath)
+        let updatedTarget = updatedProject.pbxproj.nativeTargets.first { $0.name == "TestTarget" }
+        let resourcesPhase = updatedTarget?.buildPhases.first { $0 is PBXResourcesBuildPhase }
+        #expect(resourcesPhase != nil)
+    }
+
+    @Test("Fails when folder does not exist")
+    func failsWhenFolderDoesNotExist() throws {
+        let tool = AddFolderTool(pathUtility: pathUtility)
+
+        // Create a test project
+        let projectPath = Path(tempDir) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
+
+        // Try to add a non-existent folder
+        #expect(throws: MCPError.self) {
+            try tool.execute(arguments: [
+                "project_path": .string(projectPath.string),
+                "folder_path": .string("/path/that/does/not/exist"),
+            ])
+        }
+
+        // Clean up
+        try FileManager.default.removeItem(atPath: projectPath.string)
+    }
+
+    @Test("Fails when path is not a directory")
+    func failsWhenPathIsNotDirectory() throws {
+        let tool = AddFolderTool(pathUtility: pathUtility)
+
+        // Create a test project
+        let projectPath = Path(tempDir) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
+
+        // Create a file instead of a folder
+        let filePath = Path(tempDir) + "TestFile.txt"
+        try "test content".write(
+            to: URL(filePath: filePath.string), atomically: true, encoding: .utf8)
+
+        // Try to add a file as a folder
+        #expect(throws: MCPError.self) {
+            try tool.execute(arguments: [
+                "project_path": .string(projectPath.string),
+                "folder_path": .string(filePath.string),
+            ])
+        }
+
+        // Clean up
+        try FileManager.default.removeItem(atPath: projectPath.string)
+        try FileManager.default.removeItem(atPath: filePath.string)
+    }
+}

--- a/Tests/XcodeProjectMCPTests/AddFolderToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddFolderToolTests.swift
@@ -20,8 +20,9 @@ struct AddFolderToolTests {
     func toolProperties() {
         let tool = AddFolderTool(pathUtility: pathUtility)
 
-        #expect(tool.tool().name == "add_folder")
-        #expect(tool.tool().description == "Add a folder reference to an Xcode project")
+        #expect(tool.tool().name == "add_synchronized_folder")
+        #expect(
+            tool.tool().description == "Add a synchronized folder reference to an Xcode project")
 
         let schema = tool.tool().inputSchema
         if case let .object(schemaDict) = schema {


### PR DESCRIPTION
This commit implements a new MCP tool that adds file system synchronized folder references to Xcode projects using PBXFileSystemSynchronizedRootGroup.

Features:
- Add folder references to Xcode projects
- Support for adding to specific groups
- Support for adding to build targets (resources phase)
- Comprehensive error handling and validation
- Full test coverage with swift-testing framework

The tool validates that the specified path exists and is a directory before adding it to the project. It supports both relative and absolute paths and integrates properly with the existing MCP server infrastructure.

🤖 Generated with [Claude Code](https://claude.ai/code)