### PR TITLE
Add --verbose flag to control log level

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1ae5d311c86561b2857961d73b75d513a0e4e63457dd1ac91ad79e0550baac20",
+  "originHash" : "7b21ff2322b84e8971420d28832e7e29f82a736581a055373e265fa1a90fe456",
   "pins" : [
     {
       "identity" : "aexml",
@@ -35,6 +35,15 @@
       "state" : {
         "revision" : "26cc5e9ae0947092c7139ef7ba612e34646086c7",
         "version" : "0.10.1"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk", from: "0.9.0"),
         .package(url: "https://github.com/tuist/xcodeproj", from: "9.4.2"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.0"),
     ],
     targets: [
         .target(
@@ -33,7 +34,8 @@ let package = Package(
         .executableTarget(
             name: "xcodeproj-mcp-server",
             dependencies: [
-                "XcodeProjectMCP"
+                "XcodeProjectMCP",
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ]
         ),
         .testTarget(


### PR DESCRIPTION
## Summary
- Add `swift-argument-parser` 1.7.0 dependency for CLI argument handling
- Change default log level from `debug` to `info` for cleaner output
- Add `--verbose` / `-v` flag to enable debug logging when needed

## Usage
```bash
# Default (info level logging)
xcodeproj-mcp-server

# With base path
xcodeproj-mcp-server /path/to/workspace

# Verbose mode (debug level logging)
xcodeproj-mcp-server --verbose
xcodeproj-mcp-server -v

# Both
xcodeproj-mcp-server /path/to/workspace --verbose
```

Closes #10

## Test plan
- [x] `swift build` succeeds
- [x] `swift test` passes (148 tests)
- [x] `--help` shows new options correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)