### PR TITLE
Update MCP Swift SDK to 0.12.0 for Swift 6.3 compatibility

### DIFF
--- a/.github/workflows/swift-format.yml
+++ b/.github/workflows/swift-format.yml
@@ -8,15 +8,13 @@ on:
 
 jobs:
   swift-format:
-    runs-on: macos-15
-    
+    runs-on: macos-26
+
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up Swift
-      uses: swift-actions/setup-swift@v2
-      with:
-        swift-version: '6.1'
+
+    - name: Select Xcode version
+      run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     
     - name: Run swift format lint
       run: swift format lint -s -r .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   test:
-    runs-on: macos-15
-    
+    runs-on: macos-26
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Select Xcode version
-      run: sudo xcode-select -s /Applications/Xcode_16.3.app/Contents/Developer
+      run: sudo xcode-select -s /Applications/Xcode_26.4.app/Contents/Developer
     
     - name: Show Xcode version
       run: xcodebuild -version

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7b21ff2322b84e8971420d28832e7e29f82a736581a055373e265fa1a90fe456",
+  "originHash" : "7e41ded66b5ac4f540acef219352256dc2e486bbaff15c601fb230f7312c0646",
   "pins" : [
     {
       "identity" : "aexml",
@@ -13,7 +13,7 @@
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/loopwork-ai/eventsource.git",
+      "location" : "https://github.com/mattt/eventsource.git",
       "state" : {
         "revision" : "07957602bb99a5355c810187e66e6ce378a1057d",
         "version" : "1.1.1"
@@ -47,6 +47,24 @@
       }
     },
     {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
@@ -56,12 +74,21 @@
       }
     },
     {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
+        "version" : "2.97.1"
+      }
+    },
+    {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/modelcontextprotocol/swift-sdk",
       "state" : {
-        "revision" : "9742933d2ff250212a04aed39b123bcc63a21e9c",
-        "version" : "0.9.0"
+        "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
+        "version" : "0.12.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk", from: "0.9.0"),
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk", from: "0.12.0"),
         .package(url: "https://github.com/tuist/xcodeproj", from: "9.4.2"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.7.0"),
     ],

--- a/Tests/XcodeProjectMCPTests/AddAppExtensionToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddAppExtensionToolTests.swift
@@ -101,7 +101,7 @@ struct AddAppExtensionToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -152,7 +152,7 @@ struct AddAppExtensionToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -192,7 +192,7 @@ struct AddAppExtensionToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -233,7 +233,7 @@ struct AddAppExtensionToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -278,7 +278,7 @@ struct AddAppExtensionToolTests {
         // Add second time
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -310,7 +310,7 @@ struct AddAppExtensionToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -381,7 +381,7 @@ struct AddAppExtensionToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -414,7 +414,7 @@ struct AddAppExtensionToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/AddBuildPhaseToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddBuildPhaseToolTests.swift
@@ -89,7 +89,7 @@ struct AddBuildPhaseToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -150,7 +150,7 @@ struct AddBuildPhaseToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -288,7 +288,7 @@ struct AddBuildPhaseToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains not found message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/AddDependencyToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddDependencyToolTests.swift
@@ -83,7 +83,7 @@ struct AddDependencyToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -141,7 +141,7 @@ struct AddDependencyToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains already exists message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -173,7 +173,7 @@ struct AddDependencyToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains not found message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -206,7 +206,7 @@ struct AddDependencyToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains not found message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/AddFileToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddFileToolTests.swift
@@ -69,7 +69,7 @@ struct AddFileToolTests {
         let result = try tool.execute(arguments: arguments)
 
         #expect(result.content.count == 1)
-        if case let .text(content) = result.content[0] {
+        if case let .text(content, _, _) = result.content[0] {
             #expect(content.contains("Successfully added file 'file.swift'"))
         } else {
             Issue.record("Expected text content")
@@ -107,7 +107,7 @@ struct AddFileToolTests {
         let result = try tool.execute(arguments: arguments)
 
         #expect(result.content.count == 1)
-        if case let .text(content) = result.content[0] {
+        if case let .text(content, _, _) = result.content[0] {
             #expect(content.contains("Successfully added file 'file.swift'"))
         } else {
             Issue.record("Expected text content")
@@ -146,7 +146,7 @@ struct AddFileToolTests {
         let result = try tool.execute(arguments: arguments)
 
         #expect(result.content.count == 1)
-        if case let .text(content) = result.content[0] {
+        if case let .text(content, _, _) = result.content[0] {
             #expect(content.contains("Successfully added file 'file.swift' to target 'TestApp'"))
         } else {
             Issue.record("Expected text content")

--- a/Tests/XcodeProjectMCPTests/AddFolderToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddFolderToolTests.swift
@@ -87,7 +87,7 @@ struct AddFolderToolTests {
         ])
 
         // Verify the result
-        if case let .text(message) = result.content.first {
+        if case let .text(message, _, _) = result.content.first {
             #expect(message.contains("Successfully added folder reference 'TestFolder'"))
         } else {
             Issue.record("Expected text result")
@@ -130,7 +130,7 @@ struct AddFolderToolTests {
         ])
 
         // Verify the result
-        if case let .text(message) = result.content.first {
+        if case let .text(message, _, _) = result.content.first {
             #expect(message.contains("Successfully added folder reference 'TestFolder'"))
             #expect(message.contains("in group 'CustomGroup'"))
         } else {
@@ -165,7 +165,7 @@ struct AddFolderToolTests {
         ])
 
         // Verify the result
-        if case let .text(message) = result.content.first {
+        if case let .text(message, _, _) = result.content.first {
             #expect(message.contains("Successfully added folder reference 'TestFolder'"))
             #expect(message.contains("to target 'TestTarget'"))
         } else {

--- a/Tests/XcodeProjectMCPTests/AddFrameworkToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddFrameworkToolTests.swift
@@ -73,7 +73,7 @@ struct AddFrameworkToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -124,7 +124,7 @@ struct AddFrameworkToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -160,7 +160,7 @@ struct AddFrameworkToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -212,7 +212,7 @@ struct AddFrameworkToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains already exists message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -244,7 +244,7 @@ struct AddFrameworkToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains not found message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/AddSwiftPackageToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddSwiftPackageToolTests.swift
@@ -68,7 +68,7 @@ struct AddSwiftPackageToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -109,7 +109,7 @@ struct AddSwiftPackageToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -147,7 +147,7 @@ struct AddSwiftPackageToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -188,7 +188,7 @@ struct AddSwiftPackageToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -234,7 +234,7 @@ struct AddSwiftPackageToolTests {
         // Try to add same package again
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/AddTargetToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddTargetToolTests.swift
@@ -84,7 +84,7 @@ struct AddTargetToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -138,7 +138,7 @@ struct AddTargetToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -183,7 +183,7 @@ struct AddTargetToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -223,7 +223,7 @@ struct AddTargetToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains already exists message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -281,7 +281,7 @@ struct AddTargetToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -315,7 +315,7 @@ struct AddTargetToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -349,7 +349,7 @@ struct AddTargetToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -384,7 +384,7 @@ struct AddTargetToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -419,7 +419,7 @@ struct AddTargetToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -453,7 +453,7 @@ struct AddTargetToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -488,7 +488,7 @@ struct AddTargetToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/CreateGroupToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/CreateGroupToolTests.swift
@@ -60,7 +60,7 @@ struct CreateGroupToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -99,7 +99,7 @@ struct CreateGroupToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -147,7 +147,7 @@ struct CreateGroupToolTests {
         let result = try tool.execute(arguments: childArgs)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -196,7 +196,7 @@ struct CreateGroupToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains already exists message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/DuplicateTargetToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/DuplicateTargetToolTests.swift
@@ -73,7 +73,7 @@ struct DuplicateTargetToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -120,7 +120,7 @@ struct DuplicateTargetToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -161,7 +161,7 @@ struct DuplicateTargetToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains not found message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -204,7 +204,7 @@ struct DuplicateTargetToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains already exists message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -255,7 +255,7 @@ struct DuplicateTargetToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/GetBuildSettingsToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/GetBuildSettingsToolTests.swift
@@ -100,7 +100,7 @@ struct GetBuildSettingsToolTests {
         let result = try tool.execute(arguments: arguments)
 
         #expect(result.content.count == 1)
-        if case let .text(content) = result.content[0] {
+        if case let .text(content, _, _) = result.content[0] {
             #expect(content.contains("Build settings for target 'TestApp'"))
             #expect(content.contains("PRODUCT_NAME") || content.contains("BUNDLE_IDENTIFIER"))
         } else {
@@ -135,7 +135,7 @@ struct GetBuildSettingsToolTests {
         let result = try tool.execute(arguments: arguments)
 
         #expect(result.content.count == 1)
-        if case let .text(content) = result.content[0] {
+        if case let .text(content, _, _) = result.content[0] {
             #expect(content.contains("Build settings for target 'TestApp' (Release)"))
         } else {
             Issue.record("Expected text content")

--- a/Tests/XcodeProjectMCPTests/ListBuildConfigurationsToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/ListBuildConfigurationsToolTests.swift
@@ -59,7 +59,7 @@ struct ListBuildConfigurationsToolTests {
         let result = try tool.execute(arguments: listArguments)
 
         #expect(result.content.count == 1)
-        if case let .text(content) = result.content[0] {
+        if case let .text(content, _, _) = result.content[0] {
             #expect(content.contains("TestProject.xcodeproj"))
             #expect(content.contains("Debug") || content.contains("Release"))
         } else {

--- a/Tests/XcodeProjectMCPTests/ListFilesToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/ListFilesToolTests.swift
@@ -67,7 +67,7 @@ struct ListFilesToolTests {
         let result = try tool.execute(arguments: listArguments)
 
         #expect(result.content.count == 1)
-        if case let .text(content) = result.content[0] {
+        if case let .text(content, _, _) = result.content[0] {
             #expect(content.contains("TestProject"))
             #expect(content.contains("No files found"))
         } else {
@@ -151,7 +151,7 @@ struct ListFilesToolTests {
         let result = try tool.execute(arguments: listArguments)
 
         #expect(result.content.count == 1)
-        if case let .text(content) = result.content[0] {
+        if case let .text(content, _, _) = result.content[0] {
             #expect(content.contains("TestFile.swift"))
         } else {
             Issue.record("Expected text content")

--- a/Tests/XcodeProjectMCPTests/ListGroupsToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/ListGroupsToolTests.swift
@@ -73,7 +73,7 @@ struct ListGroupsToolTests {
         ])
 
         // Verify the result
-        if case let .text(message) = result.content.first {
+        if case let .text(message, _, _) = result.content.first {
             #expect(
                 message.contains("Groups, folder references, and synchronized groups in project:"))
             // The default project should contain at least a Products group
@@ -121,7 +121,7 @@ struct ListGroupsToolTests {
         ])
 
         // Verify the result
-        if case let .text(message) = result.content.first {
+        if case let .text(message, _, _) = result.content.first {
             #expect(
                 message.contains("Groups, folder references, and synchronized groups in project:"))
             #expect(message.contains("- TopLevel"))
@@ -185,7 +185,7 @@ struct ListGroupsToolTests {
         ])
 
         // Verify the result
-        if case let .text(message) = result.content.first {
+        if case let .text(message, _, _) = result.content.first {
             #expect(
                 message.contains("Groups, folder references, and synchronized groups in project:"))
             #expect(message.contains("- Products"))
@@ -232,7 +232,7 @@ struct ListGroupsToolTests {
         ])
 
         // Verify the result
-        if case let .text(message) = result.content.first {
+        if case let .text(message, _, _) = result.content.first {
             #expect(
                 message.contains("Groups, folder references, and synchronized groups in project:"))
             #expect(message.contains("- Sources"))

--- a/Tests/XcodeProjectMCPTests/ListSwiftPackagesToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/ListSwiftPackagesToolTests.swift
@@ -47,7 +47,7 @@ struct ListSwiftPackagesToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -99,7 +99,7 @@ struct ListSwiftPackagesToolTests {
 
         let result = try listTool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -147,7 +147,7 @@ struct ListSwiftPackagesToolTests {
 
         let result = try listTool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -198,7 +198,7 @@ struct ListSwiftPackagesToolTests {
 
         let result = try listTool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/ListTargetsToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/ListTargetsToolTests.swift
@@ -59,7 +59,7 @@ struct ListTargetsToolTests {
         let result = try tool.execute(arguments: listArguments)
 
         #expect(result.content.count == 1)
-        if case let .text(content) = result.content[0] {
+        if case let .text(content, _, _) = result.content[0] {
             #expect(content.contains("TestProject.xcodeproj"))
             #expect(content.contains("No targets found"))
         } else {

--- a/Tests/XcodeProjectMCPTests/MoveFileToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/MoveFileToolTests.swift
@@ -97,7 +97,7 @@ struct MoveFileToolTests {
         let result = try moveTool.execute(arguments: moveArgs)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -165,7 +165,7 @@ struct MoveFileToolTests {
         let result = try moveTool.execute(arguments: moveArgs)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -206,7 +206,7 @@ struct MoveFileToolTests {
         let result = try moveTool.execute(arguments: moveArgs)
 
         // Check the result contains not found message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/RemoveAppExtensionToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/RemoveAppExtensionToolTests.swift
@@ -75,7 +75,7 @@ struct RemoveAppExtensionToolTests {
             "extension_name": Value.string("MyWidget"),
         ])
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -112,7 +112,7 @@ struct RemoveAppExtensionToolTests {
             "extension_name": Value.string("NonExistentWidget"),
         ])
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -140,7 +140,7 @@ struct RemoveAppExtensionToolTests {
             "extension_name": Value.string("TestApp"),
         ])
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/RemoveFileToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/RemoveFileToolTests.swift
@@ -75,7 +75,7 @@ struct RemoveFileToolTests {
         let result = try removeTool.execute(arguments: removeArgs)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -140,7 +140,7 @@ struct RemoveFileToolTests {
         let result = try removeTool.execute(arguments: removeArgs)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -173,7 +173,7 @@ struct RemoveFileToolTests {
         let result = try removeTool.execute(arguments: removeArgs)
 
         // Check the result contains not found message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/RemoveSwiftPackageToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/RemoveSwiftPackageToolTests.swift
@@ -58,7 +58,7 @@ struct RemoveSwiftPackageToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -100,7 +100,7 @@ struct RemoveSwiftPackageToolTests {
 
         let result = try removeTool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -155,7 +155,7 @@ struct RemoveSwiftPackageToolTests {
 
         let result = try removeTool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -207,7 +207,7 @@ struct RemoveSwiftPackageToolTests {
 
         let result = try removeTool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/RemoveTargetToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/RemoveTargetToolTests.swift
@@ -67,7 +67,7 @@ struct RemoveTargetToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -103,7 +103,7 @@ struct RemoveTargetToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains not found message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -146,7 +146,7 @@ struct RemoveTargetToolTests {
         let result = try removeTool.execute(arguments: removeArgs)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/SetBuildSettingToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/SetBuildSettingToolTests.swift
@@ -101,7 +101,7 @@ struct SetBuildSettingToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -152,7 +152,7 @@ struct SetBuildSettingToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains success message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -201,7 +201,7 @@ struct SetBuildSettingToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains not found message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }
@@ -236,7 +236,7 @@ struct SetBuildSettingToolTests {
         let result = try tool.execute(arguments: args)
 
         // Check the result contains not found message
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }


### PR DESCRIPTION
## Summary
- Update MCP Swift SDK from 0.9.0 to 0.12.0 to fix build failure on Swift 6.3
- Swift 6.3 introduced stricter `sending` checks that cause data race errors in SDK 0.9.0's `NetworkTransport.swift`
- SDK 0.12.0 uses `swift-tools-version:6.1` which resolves these errors
- Update test pattern matching for the new `.text(text:annotations:_meta:)` enum signature

## Test plan
- [x] `swift build` passes without errors or warnings
- [x] `swift test` passes (166 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)