### PR TITLE
Fix group lookup to support hierarchical paths from list_groups

### DIFF
--- a/Sources/XcodeProjectMCP/AddFileTool.swift
+++ b/Sources/XcodeProjectMCP/AddFileTool.swift
@@ -89,12 +89,11 @@ public struct AddFileTool: Sendable {
             // Find the group to add the file to
             let targetGroup: PBXGroup
             if let groupName = groupName {
-                // Find group by name or path
-                if let foundGroup = xcodeproj.pbxproj.groups.first(where: {
-                    $0.name == groupName || $0.path == groupName
-                }) {
-                    targetGroup = foundGroup
-                } else {
+                // Find group by name, path, or hierarchical path (e.g. "Parent/Child")
+                do {
+                    targetGroup = try GroupFinder.findGroup(
+                        named: groupName, in: xcodeproj.pbxproj)
+                } catch {
                     throw MCPError.invalidParams("Group '\(groupName)' not found in project")
                 }
             } else {

--- a/Sources/XcodeProjectMCP/AddFolderTool.swift
+++ b/Sources/XcodeProjectMCP/AddFolderTool.swift
@@ -102,12 +102,11 @@ public struct AddFolderTool: Sendable {
             // Find the group to add the folder to
             let targetGroup: PBXGroup
             if let groupName = groupName {
-                // Find group by name or path
-                if let foundGroup = xcodeproj.pbxproj.groups.first(where: {
-                    $0.name == groupName || $0.path == groupName
-                }) {
-                    targetGroup = foundGroup
-                } else {
+                // Find group by name, path, or hierarchical path (e.g. "Parent/Child")
+                do {
+                    targetGroup = try GroupFinder.findGroup(
+                        named: groupName, in: xcodeproj.pbxproj)
+                } catch {
                     throw MCPError.invalidParams("Group '\(groupName)' not found in project")
                 }
             } else {

--- a/Sources/XcodeProjectMCP/CreateGroupTool.swift
+++ b/Sources/XcodeProjectMCP/CreateGroupTool.swift
@@ -87,12 +87,11 @@ public struct CreateGroupTool: Sendable {
             // Find parent group
             let parentGroup: PBXGroup
             if let parentGroupName = parentGroupName {
-                // Find specified parent group
-                if let foundGroup = xcodeproj.pbxproj.groups.first(where: {
-                    $0.name == parentGroupName
-                }) {
-                    parentGroup = foundGroup
-                } else {
+                // Find group by name, path, or hierarchical path (e.g. "Parent/Child")
+                do {
+                    parentGroup = try GroupFinder.findGroup(
+                        named: parentGroupName, in: xcodeproj.pbxproj)
+                } catch {
                     throw MCPError.invalidParams(
                         "Parent group '\(parentGroupName)' not found in project")
                 }

--- a/Sources/XcodeProjectMCP/GroupFinder.swift
+++ b/Sources/XcodeProjectMCP/GroupFinder.swift
@@ -1,0 +1,58 @@
+import Foundation
+import XcodeProj
+
+/// Utility for finding PBXGroup by hierarchical path (e.g. "TopLevel/Nested/DeeplyNested")
+/// as returned by ListGroupsTool.
+enum GroupFinder {
+    /// Find a group by name, path property, or hierarchical path.
+    /// Hierarchical paths like "Parent/Child" are resolved by traversing
+    /// the group tree from the main group.
+    static func findGroup(
+        named groupName: String,
+        in pbxproj: PBXProj
+    ) throws -> PBXGroup {
+        // First, try direct match (single-component name or path)
+        if let found = pbxproj.groups.first(where: {
+            $0.name == groupName || $0.path == groupName
+        }) {
+            return found
+        }
+
+        // If the name contains "/", try hierarchical traversal
+        let components = groupName.split(separator: "/").map(String.init)
+        if components.count > 1 {
+            guard let project = try pbxproj.rootProject(),
+                let mainGroup = project.mainGroup
+            else {
+                throw GroupFinderError.groupNotFound(groupName)
+            }
+
+            var currentGroup = mainGroup
+            for component in components {
+                guard
+                    let childGroup = currentGroup.children.compactMap({ $0 as? PBXGroup }).first(
+                        where: {
+                            $0.name == component || $0.path == component
+                        })
+                else {
+                    throw GroupFinderError.groupNotFound(groupName)
+                }
+                currentGroup = childGroup
+            }
+            return currentGroup
+        }
+
+        throw GroupFinderError.groupNotFound(groupName)
+    }
+
+    enum GroupFinderError: LocalizedError {
+        case groupNotFound(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .groupNotFound(let name):
+                return "Group '\(name)' not found in project"
+            }
+        }
+    }
+}

--- a/Tests/XcodeProjectMCPTests/AddFileToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddFileToolTests.swift
@@ -120,6 +120,86 @@ struct AddFileToolTests {
         #expect(addedFile != nil)
     }
 
+    @Test func testAddFileToNestedGroup() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        let tool = AddFileTool(pathUtility: PathUtility(basePath: tempDir.path))
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        // Create a test project with nested groups: TopLevel -> Nested -> DeeplyNested
+        let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProjectWithNestedGroups(
+            name: "TestProject", at: projectPath)
+
+        // Add a file using hierarchical group path "TopLevel/Nested"
+        let arguments: [String: Value] = [
+            "project_path": Value.string(projectPath.string),
+            "file_path": Value.string(tempDir.appendingPathComponent("file.swift").path),
+            "group_name": Value.string("TopLevel/Nested"),
+        ]
+
+        let result = try tool.execute(arguments: arguments)
+
+        #expect(result.content.count == 1)
+        if case let .text(content) = result.content[0] {
+            #expect(content.contains("Successfully added file 'file.swift'"))
+        } else {
+            Issue.record("Expected text content")
+        }
+
+        // Verify the file was added to the "Nested" group specifically
+        let xcodeproj = try XcodeProj(path: projectPath)
+        let nestedGroup = xcodeproj.pbxproj.groups.first { $0.name == "Nested" }
+        #expect(nestedGroup != nil)
+        let addedFile = nestedGroup?.children.compactMap { $0 as? PBXFileReference }.first {
+            $0.name == "file.swift"
+        }
+        #expect(addedFile != nil)
+    }
+
+    @Test func testAddFileToDeeplyNestedGroup() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        let tool = AddFileTool(pathUtility: PathUtility(basePath: tempDir.path))
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProjectWithNestedGroups(
+            name: "TestProject", at: projectPath)
+
+        // Add a file using hierarchical group path "TopLevel/Nested/DeeplyNested"
+        let arguments: [String: Value] = [
+            "project_path": Value.string(projectPath.string),
+            "file_path": Value.string(tempDir.appendingPathComponent("deep.swift").path),
+            "group_name": Value.string("TopLevel/Nested/DeeplyNested"),
+        ]
+
+        let result = try tool.execute(arguments: arguments)
+
+        if case let .text(content) = result.content[0] {
+            #expect(content.contains("Successfully added file 'deep.swift'"))
+        } else {
+            Issue.record("Expected text content")
+        }
+
+        // Verify the file was added to the "DeeplyNested" group
+        let xcodeproj = try XcodeProj(path: projectPath)
+        let deepGroup = xcodeproj.pbxproj.groups.first { $0.name == "DeeplyNested" }
+        #expect(deepGroup != nil)
+        let addedFile = deepGroup?.children.compactMap { $0 as? PBXFileReference }.first {
+            $0.name == "deep.swift"
+        }
+        #expect(addedFile != nil)
+    }
+
     @Test func testAddFileToTarget() throws {
         // Create a temporary directory
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(

--- a/Tests/XcodeProjectMCPTests/AddFileToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddFileToolTests.swift
@@ -145,7 +145,7 @@ struct AddFileToolTests {
         let result = try tool.execute(arguments: arguments)
 
         #expect(result.content.count == 1)
-        if case let .text(content) = result.content[0] {
+        if case let .text(content, _, _) = result.content[0] {
             #expect(content.contains("Successfully added file 'file.swift'"))
         } else {
             Issue.record("Expected text content")
@@ -184,7 +184,7 @@ struct AddFileToolTests {
 
         let result = try tool.execute(arguments: arguments)
 
-        if case let .text(content) = result.content[0] {
+        if case let .text(content, _, _) = result.content[0] {
             #expect(content.contains("Successfully added file 'deep.swift'"))
         } else {
             Issue.record("Expected text content")

--- a/Tests/XcodeProjectMCPTests/CreateGroupToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/CreateGroupToolTests.swift
@@ -203,6 +203,47 @@ struct CreateGroupToolTests {
         #expect(message.contains("already exists"))
     }
 
+    @Test("Create group in nested parent group using hierarchical path")
+    func createGroupInNestedParentGroup() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProjectWithNestedGroups(
+            name: "TestProject", at: projectPath)
+
+        let tool = CreateGroupTool(pathUtility: PathUtility(basePath: tempDir.path))
+
+        // Create a group using hierarchical parent path "TopLevel/Nested"
+        let args: [String: Value] = [
+            "project_path": Value.string(projectPath.string),
+            "group_name": Value.string("NewChild"),
+            "parent_group": Value.string("TopLevel/Nested"),
+        ]
+
+        let result = try tool.execute(arguments: args)
+
+        guard case let .text(message) = result.content.first else {
+            Issue.record("Expected text result")
+            return
+        }
+        #expect(message.contains("Successfully created group 'NewChild'"))
+
+        // Verify NewChild was added to the "Nested" group
+        let xcodeproj = try XcodeProj(path: projectPath)
+        let nestedGroup = xcodeproj.pbxproj.groups.first { $0.name == "Nested" }
+        #expect(nestedGroup != nil)
+        let newChild = nestedGroup?.children.compactMap { $0 as? PBXGroup }.first {
+            $0.name == "NewChild"
+        }
+        #expect(newChild != nil)
+    }
+
     @Test("Create group with non-existent parent")
     func createGroupWithNonExistentParent() throws {
         // Create a temporary directory

--- a/Tests/XcodeProjectMCPTests/CreateGroupToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/CreateGroupToolTests.swift
@@ -228,7 +228,7 @@ struct CreateGroupToolTests {
 
         let result = try tool.execute(arguments: args)
 
-        guard case let .text(message) = result.content.first else {
+        guard case let .text(message, _, _) = result.content.first else {
             Issue.record("Expected text result")
             return
         }

--- a/Tests/XcodeProjectMCPTests/TestProjectHelper.swift
+++ b/Tests/XcodeProjectMCPTests/TestProjectHelper.swift
@@ -55,6 +55,62 @@ struct TestProjectHelper {
         try xcodeproj.write(path: path)
     }
 
+    /// Create a test project with nested groups: TopLevel -> Nested -> DeeplyNested
+    static func createTestProjectWithNestedGroups(name: String, at path: Path) throws {
+        let pbxproj = PBXProj()
+
+        // Create nested groups
+        let deeplyNestedGroup = PBXGroup(
+            children: [], sourceTree: .group, name: "DeeplyNested", path: "DeeplyNested")
+        pbxproj.add(object: deeplyNestedGroup)
+
+        let nestedGroup = PBXGroup(
+            children: [deeplyNestedGroup], sourceTree: .group, name: "Nested", path: "Nested")
+        pbxproj.add(object: nestedGroup)
+
+        let topLevelGroup = PBXGroup(
+            children: [nestedGroup], sourceTree: .group, name: "TopLevel", path: "TopLevel")
+        pbxproj.add(object: topLevelGroup)
+
+        // Create main group containing topLevelGroup
+        let mainGroup = PBXGroup(children: [topLevelGroup], sourceTree: .group)
+        pbxproj.add(object: mainGroup)
+
+        let productsGroup = PBXGroup(children: [], sourceTree: .group, name: "Products")
+        pbxproj.add(object: productsGroup)
+
+        // Create build configurations
+        let debugConfig = XCBuildConfiguration(name: "Debug", buildSettings: [:])
+        let releaseConfig = XCBuildConfiguration(name: "Release", buildSettings: [:])
+        pbxproj.add(object: debugConfig)
+        pbxproj.add(object: releaseConfig)
+
+        let configurationList = XCConfigurationList(
+            buildConfigurations: [debugConfig, releaseConfig],
+            defaultConfigurationName: "Release"
+        )
+        pbxproj.add(object: configurationList)
+
+        let project = PBXProject(
+            name: name,
+            buildConfigurationList: configurationList,
+            compatibilityVersion: "Xcode 14.0",
+            preferredProjectObjectVersion: 56,
+            minimizedProjectReferenceProxies: 0,
+            mainGroup: mainGroup,
+            developmentRegion: "en",
+            knownRegions: ["en", "Base"],
+            productsGroup: productsGroup
+        )
+        pbxproj.add(object: project)
+        pbxproj.rootObject = project
+
+        let workspaceData = XCWorkspaceData(children: [])
+        let workspace = XCWorkspace(data: workspaceData)
+        let xcodeproj = XcodeProj(workspace: workspace, pbxproj: pbxproj)
+        try xcodeproj.write(path: path)
+    }
+
     static func createTestProjectWithTarget(name: String, targetName: String, at path: Path) throws
     {
         // Create the .pbxproj file using XcodeProj


### PR DESCRIPTION
## Summary
- `list_groups` returns hierarchical paths like `"TopLevel/Nested"`, but `add_file`, `create_group`, and `add_synchronized_folder` only matched against individual group `name`/`path` properties, causing lookups to fail for nested groups
- Add `GroupFinder` utility that first tries direct match, then traverses the group tree by splitting on `/` to resolve hierarchical paths
- Fix applied to `AddFileTool`, `CreateGroupTool`, and `AddFolderTool`

## Test plan
- [x] `testAddFileToNestedGroup` — add file using `"TopLevel/Nested"` path
- [x] `testAddFileToDeeplyNestedGroup` — add file using `"TopLevel/Nested/DeeplyNested"` path
- [x] `testCreateGroupInNestedParentGroup` — create group with hierarchical parent path
- [x] Existing tests continue to pass (single-component group names still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)