### PR TITLE
fix(add_file): resolve new file references relative to the project directory, not the sandbox basePath

### DIFF
--- a/Sources/XcodeProjectMCP/AddFileTool.swift
+++ b/Sources/XcodeProjectMCP/AddFileTool.swift
@@ -74,18 +74,6 @@ public struct AddFileTool: Sendable {
 
             let xcodeproj = try XcodeProj(path: Path(projectURL.path))
 
-            // Create file reference
-            let fileName = URL(fileURLWithPath: resolvedFilePath).lastPathComponent
-            // Use relative path from project for file reference
-            let relativePath =
-                pathUtility.makeRelativePath(from: resolvedFilePath) ?? resolvedFilePath
-            let fileReference = PBXFileReference(
-                sourceTree: .group,
-                name: fileName,
-                path: relativePath
-            )
-            xcodeproj.pbxproj.add(object: fileReference)
-
             // Find the group to add the file to
             let targetGroup: PBXGroup
             if let groupName = groupName {
@@ -106,8 +94,31 @@ public struct AddFileTool: Sendable {
                 targetGroup = mainGroup
             }
 
+            // Create file reference
+            let fileName = URL(fileURLWithPath: resolvedFilePath).lastPathComponent
+            // A PBXFileReference with sourceTree .group resolves its `path` relative to
+            // its parent group's own resolved directory, which chains up to the
+            // directory containing the .xcodeproj -- not the MCP server's sandbox
+            // basePath. Those two directories only coincide when the .xcodeproj sits
+            // directly at basePath; for a nested project (e.g. <repo>/apps/ios/Foo.xcodeproj
+            // with basePath == <repo>) resolving relative to basePath produces a path
+            // that gets the project's own subdirectory prefix applied twice at build time.
+            let projectDirPath = Path(projectURL.deletingLastPathComponent().path)
+            let targetGroupPath = try? targetGroup.fullPath(sourceRoot: projectDirPath)
+            let relativePath =
+                PathUtility.relativePath(
+                    from: (targetGroupPath ?? projectDirPath).string, to: resolvedFilePath)
+                ?? resolvedFilePath
+            let fileReference = PBXFileReference(
+                sourceTree: .group,
+                name: fileName,
+                path: relativePath
+            )
+            xcodeproj.pbxproj.add(object: fileReference)
+
             // Add file to group
             targetGroup.children.append(fileReference)
+            fileReference.parent = targetGroup
 
             // Add file to target if specified
             if let targetName = targetName {

--- a/Sources/XcodeProjectMCP/PathUtility.swift
+++ b/Sources/XcodeProjectMCP/PathUtility.swift
@@ -58,6 +58,19 @@ public struct PathUtility: Sendable {
             return nil
         }
 
+        return PathUtility.relativePath(from: basePath, to: absolutePath)
+    }
+
+    /// Converts an absolute path to a relative path from an arbitrary directory.
+    ///
+    /// Unlike `makeRelativePath(from:)`, which is always relative to the server's
+    /// sandbox `basePath`, this lets callers compute a path relative to some other
+    /// directory -- e.g. the directory that actually governs how a `PBXFileReference`
+    /// with `sourceTree: .group` resolves on disk, which is not necessarily `basePath`.
+    public static func relativePath(from directory: String, to absolutePath: String) -> String? {
+        let baseURL = URL(fileURLWithPath: directory).standardized
+        let absoluteURL = URL(fileURLWithPath: absolutePath).standardized
+
         // Get the relative components
         let baseComponents = baseURL.pathComponents
         let absoluteComponents = absoluteURL.pathComponents

--- a/Tests/XcodeProjectMCPTests/AddFileToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddFileToolTests.swift
@@ -250,6 +250,46 @@ struct AddFileToolTests {
         #expect(buildFile != nil)
     }
 
+    @Test func testAddFileWhenProjectIsNestedUnderBasePath() throws {
+        // Mirrors a monorepo layout where the MCP server's basePath is the
+        // repo root but the .xcodeproj lives in a subdirectory, e.g.
+        // <repo>/apps/ios/TestProject.xcodeproj with basePath == <repo>.
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let projectDir = tempDir.appendingPathComponent("apps/ios")
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+
+        let tool = AddFileTool(pathUtility: PathUtility(basePath: tempDir.path))
+
+        let projectPath = Path(projectDir.path) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
+
+        // file_path is given relative to basePath (the repo root), as callers do today.
+        let arguments: [String: Value] = [
+            "project_path": Value.string(projectPath.string),
+            "file_path": Value.string("apps/ios/TestProject/file.swift"),
+        ]
+
+        _ = try tool.execute(arguments: arguments)
+
+        let xcodeproj = try XcodeProj(path: projectPath)
+        let addedFile = xcodeproj.pbxproj.fileReferences.first { $0.name == "file.swift" }
+        #expect(addedFile != nil)
+
+        // The stored path must resolve, relative to the project's own directory,
+        // to the file's real on-disk location -- not be doubled up with the
+        // project's own subdirectory prefix (e.g. apps/ios/apps/ios/...).
+        let sourceRoot = Path(projectDir.path)
+        let expected = Path(tempDir.appendingPathComponent("apps/ios/TestProject/file.swift").path)
+        let resolved = try addedFile?.fullPath(sourceRoot: sourceRoot)
+        #expect(resolved == expected)
+    }
+
     @Test func testAddFileWithNonexistentTarget() throws {
         // Create a temporary directory
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(


### PR DESCRIPTION
## Summary

`add_file` computes a new `PBXFileReference`'s `path` using `PathUtility.makeRelativePath(from:)`, which is always relative to the server's sandbox `basePath` (the directory the server was started in). But a `PBXFileReference` with `sourceTree: .group` is resolved by Xcode relative to its **parent group's own directory**, which chains up to the directory containing the `.xcodeproj` -- not the server's `basePath`.

These two directories only coincide when the `.xcodeproj` sits directly at `basePath`. For a nested project layout, e.g.:

```
<repo>/                      <- basePath (server started here)
<repo>/apps/ios/Foo.xcodeproj
```

`add_file` computes the new reference's path relative to `<repo>` instead of relative to `<repo>/apps/ios`, which bakes the project's own subdirectory prefix (`apps/ios`) into the stored path a second time. At build time Xcode resolves it as `apps/ios/apps/ios/...`, a path that doesn't exist.

This went unnoticed because every existing `AddFileToolTests` case places the `.xcodeproj` directly at `basePath`, which structurally can't expose the divergence between "sandbox root" and "project root".

## Fix

- Added `PathUtility.relativePath(from:to:)`, a generic version of the existing `makeRelativePath(from:)` helper parameterized on an arbitrary base directory (kept `makeRelativePath` itself unchanged for existing call sites).
- In `AddFileTool`, resolve the target group first, then use `XcodeProj`'s own `PBXFileElement.fullPath(sourceRoot:)` to get that group's actual resolved on-disk directory, and compute the new file reference's path relative to *that* -- matching how Xcode itself resolves group-relative paths.

## Test plan

- [x] Added `testAddFileWhenProjectIsNestedUnderBasePath`, which places the `.xcodeproj` in a subdirectory of `basePath` (mirroring a monorepo layout) and asserts the stored file reference resolves, via `fullPath(sourceRoot:)`, to the correct on-disk location.
- [x] Confirmed the new test fails against `main` with the exact reported doubling (`apps/ios/apps/ios/...`) and passes after the fix.
- [x] Full suite: `swift test` -- 170/170 passing, no regressions.
- [x] `swift build -c release` succeeds.
- [x] `swift format -r -i .` -- no additional changes needed.

## Note

The same `pathUtility.makeRelativePath(from: resolvedX)` pattern (relative to sandbox `basePath` rather than the project directory) also appears in `AddFrameworkTool`, `AddFolderTool`, `RemoveFileTool`, `MoveFileTool`, and `AddBuildPhaseTool`. I scoped this PR to `add_file` since that's the tool where the bug was reported and reproduced, but those other tools may have the same issue for nested projects and could be worth a follow-up look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)