### PR TITLE
Document Apple container as the recommended runtime, and MCP setup inside Xcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,90 @@ This server enables AI assistants and other MCP clients to:
 
 ### Prerequisites
 
-- Docker
 - macOS (for running Xcode projects)
+- A container runtime — either [Apple's `container`](#setup-with-apples-container-recommended) (recommended) or [Docker](#setup-with-docker)
 
-### Installation using Docker
+The server is distributed as a `linux/arm64` container image, which runs on either runtime.
+
+### Setup with Apple's `container` (recommended)
+
+[`container`](https://github.com/apple/container) is Apple's own tool for running Linux containers as lightweight virtual machines on macOS. It is the recommended runtime for this server: it comes from Apple, requires no third-party desktop application, and runs the published `linux/arm64` image natively on Apple silicon.
+
+#### Requirements
+
+- A Mac with Apple silicon
+- macOS 26 or later (`container` does not support older versions)
+
+#### Installation
+
+Install the `container` CLI from the [official release page](https://github.com/apple/container/releases).
+
+`container` needs its background service running. Start it once after installing, and again after each reboot:
+
+```bash
+container system start
+```
+
+Then pull the pre-built image from GitHub Container Registry:
+
+```bash
+container image pull ghcr.io/giginet/xcodeproj-mcp-server:latest
+```
+
+`container run` has no `--pull` option, so run `container image pull` again whenever you want to update to the latest image.
+
+#### Configuration for Claude Code
+
+```bash
+claude mcp add xcodeproj -- container run --rm -i -v $PWD:/workspace ghcr.io/giginet/xcodeproj-mcp-server:latest /workspace
+```
+
+We need to mount the current working directory (`$PWD`) to `/workspace` inside the container. This allows the server to access your Xcode projects.
+
+#### Configuration for Claude Desktop
+
+Add the following to your Claude Desktop configuration file:
+
+**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "xcodeproj": {
+      "command": "/usr/local/bin/container",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-v",
+        "${workspaceFolder}:/workspace",
+        "ghcr.io/giginet/xcodeproj-mcp-server",
+        "/workspace"
+      ]
+    }
+  }
+}
+```
+
+The installer places the binary at `/usr/local/bin/container`. The absolute path is used here because that directory is not always on the `PATH` of GUI applications.
+
+#### Building the image locally
+
+`container build` reads the same `Dockerfile`:
+
+```bash
+container build -t xcodeproj-mcp-server:local .
+```
+
+The builder container defaults to 2 CPUs and 2 GB of memory. Allocate more to it to speed up the release build:
+
+```bash
+container build -c 8 -m 8g -t xcodeproj-mcp-server:local .
+```
+
+### Setup with Docker
+
+Use Docker if you are on macOS 15 or earlier, or if Docker is already part of your workflow.
 
 Pull the pre-built Docker image from GitHub Container Registry:
 
@@ -57,27 +137,15 @@ Pull the pre-built Docker image from GitHub Container Registry:
 docker pull ghcr.io/giginet/xcodeproj-mcp-server
 ```
 
-### Configuration for Claude Code
+#### Configuration for Claude Code
 
 ```bash
 claude mcp add xcodeproj -- docker run --pull=always --rm -i -v $PWD:/workspace ghcr.io/giginet/xcodeproj-mcp-server:latest /workspace
 ```
 
-We need to mount the current working directory (`$PWD`) to `/workspace` inside the container. This allows the server to access your Xcode projects.
+As with `container`, the current working directory (`$PWD`) is mounted to `/workspace` inside the container so that the server can access your Xcode projects.
 
-#### Recommended settings
-
-Enabling `ENABLE_TOOL_SEARCH` in `.claude/settings.json` activates dynamic MCP tool loading. This prevents unused MCP tools from consuming context.
-
-```json
-{
-  "env": {
-    "ENABLE_TOOL_SEARCH": "1"
-  }
-}
-```
-
-### Configuration for Claude Desktop
+#### Configuration for Claude Desktop
 
 Add the following to your Claude Desktop configuration file:
 
@@ -102,6 +170,18 @@ Add the following to your Claude Desktop configuration file:
 }
 ```
 
+### Recommended settings for Claude Code
+
+Enabling `ENABLE_TOOL_SEARCH` in `.claude/settings.json` activates dynamic MCP tool loading. This prevents unused MCP tools from consuming context.
+
+```json
+{
+  "env": {
+    "ENABLE_TOOL_SEARCH": "1"
+  }
+}
+```
+
 ### Path Security
 
 The MCP server now supports restricting file operations to a specific base directory. When you provide a base path as a command-line argument:
@@ -110,7 +190,7 @@ The MCP server now supports restricting file operations to a specific base direc
 - Absolute paths are validated to ensure they're within the base directory
 - Any attempt to access files outside the base directory will result in an error
 
-This is especially useful when running the server in Docker containers or other sandboxed environments.
+This is especially useful when running the server in containers or other sandboxed environments.
 
 ## Available Tools
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,67 @@ Add the following to your Claude Desktop configuration file:
 }
 ```
 
+### Using the server from Claude Code or Codex inside Xcode
+
+Xcode can run Claude Code and Codex as coding agents, and it reads their configuration from agent-specific subfolders of `~/Library/Developer/Xcode/CodingAssistant`, a folder Xcode uses exclusively. Configuration placed there affects agents only when you launch them in Xcode, so it does not interfere with your regular `~/.claude` or `~/.codex` setup. See Apple's [Extending and customizing agents](https://developer.apple.com/documentation/xcode/extending-and-customizing-agents#Customize-agent-environments) for details.
+
+Two things differ from the command-line setup:
+
+- Xcode launches the MCP server with the project directory as its working directory, so mount `.` rather than `$PWD`.
+- Give `command` an absolute path, because the agent's environment does not necessarily have `/usr/local/bin` on its `PATH`.
+
+#### Claude Code in Xcode
+
+`~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig` acts as Claude Code's configuration directory. Point `CLAUDE_CONFIG_DIR` at it and use `claude mcp add`:
+
+```bash
+CLAUDE_CONFIG_DIR=~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig \
+  claude mcp add xcodeproj -s user -- \
+  /usr/local/bin/container run --rm -i -v .:/workspace ghcr.io/giginet/xcodeproj-mcp-server:latest /workspace
+```
+
+That writes the server into `ClaudeAgentConfig/.claude.json`. To add it by hand instead, add an entry under `mcpServers`:
+
+```json
+{
+  "mcpServers": {
+    "xcodeproj": {
+      "type": "stdio",
+      "command": "/usr/local/bin/container",
+      "args": [
+        "run",
+        "--rm",
+        "-i",
+        "-v",
+        ".:/workspace",
+        "ghcr.io/giginet/xcodeproj-mcp-server:latest",
+        "/workspace"
+      ]
+    }
+  }
+}
+```
+
+#### Codex in Xcode
+
+`~/Library/Developer/Xcode/CodingAssistant/codex` acts as Codex's `CODEX_HOME`:
+
+```bash
+CODEX_HOME=~/Library/Developer/Xcode/CodingAssistant/codex \
+  codex mcp add xcodeproj -- \
+  /usr/local/bin/container run --rm -i -v .:/workspace ghcr.io/giginet/xcodeproj-mcp-server:latest /workspace
+```
+
+That writes the server into `codex/config.toml`. To add it by hand instead:
+
+```toml
+[mcp_servers.xcodeproj]
+command = "/usr/local/bin/container"
+args = ["run", "--rm", "-i", "-v", ".:/workspace", "ghcr.io/giginet/xcodeproj-mcp-server:latest", "/workspace"]
+```
+
+If you set up with Docker, use the absolute path to your `docker` binary in place of `/usr/local/bin/container`. Restart the agent in Xcode after changing its configuration.
+
 ### Recommended settings for Claude Code
 
 Enabling `ENABLE_TOOL_SEARCH` in `.claude/settings.json` activates dynamic MCP tool loading. This prevents unused MCP tools from consuming context.


### PR DESCRIPTION
## Summary

Two README additions:

1. **Apple's `container` as the recommended runtime**, alongside the existing Docker instructions. The published image is `linux/arm64`, so it runs natively on Apple silicon without a third-party desktop application.
2. **MCP setup for Claude Code and Codex running inside Xcode**, which needs different configuration paths than the command-line setup.

The setup section is reorganized so both runtimes are siblings, and the runtime-independent `ENABLE_TOOL_SEARCH` note is moved out of the Docker section.

## Verification

Verified end-to-end on `container` 1.2.2 (macOS 27, arm64):

- `container image pull` / `container build` from the same `Dockerfile` both work
- The MCP handshake works over `container run -i`
- Bind mounts are writable: `create_xcodeproj` → `add_file` → `list_files` succeed and the result is reflected on the host. virtiofs maps the mount to the uid of the container process, so the non-root `xcodeproj` user needs no extra options
- The exact command line documented for Xcode was run with the project directory as the working directory, confirming the relative `.:/workspace` mount

For the Xcode section, `CLAUDE_CONFIG_DIR` was confirmed to point at `~/Library/Developer/Xcode/CodingAssistant/ClaudeAgentConfig` on a running Xcode agent process, and both `claude mcp add` and `codex mcp add` were checked to write the documented file contents.

## Notes

- `container run` has no `--pull` option, so there is no equivalent of Docker's `--pull=always`; the README points at `container image pull` for updates instead.
- Xcode additionally passes its own `xcode-tools` server via `--mcp-config`. Since it does not pass `--strict-mcp-config`, user-scope servers from `.claude.json` are loaded as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ekd6pZytfBcVLerQ1YETcr