### PR TITLE
fix(move_file): keep the file reference relative to its owning group

### DIFF
--- a/Sources/XcodeProjectMCP/MoveFileTool.swift
+++ b/Sources/XcodeProjectMCP/MoveFileTool.swift
@@ -78,6 +78,8 @@ public struct MoveFileTool: Sendable {
             let newRelativePath =
                 pathUtility.makeRelativePath(from: resolvedNewPath) ?? resolvedNewPath
 
+            let projectDirPath = Path(projectURL.deletingLastPathComponent().path)
+
             var fileMoved = false
 
             // Find and update file references
@@ -86,7 +88,12 @@ public struct MoveFileTool: Sendable {
                     || fileRef.name == oldFileName || fileRef.path == oldFileName
                 {
                     // Update the file reference
-                    fileRef.path = newRelativePath
+                    fileRef.path = referencePath(
+                        for: fileRef,
+                        movedTo: resolvedNewPath,
+                        in: xcodeproj.pbxproj,
+                        projectDirectory: projectDirPath
+                    )
                     fileRef.name = newFileName
                     fileMoved = true
                 }
@@ -128,6 +135,48 @@ public struct MoveFileTool: Sendable {
         } catch {
             throw MCPError.internalError(
                 "Failed to move file in Xcode project: \(error.localizedDescription)")
+        }
+    }
+
+    /// Computes the `path` to store on a moved file reference.
+    ///
+    /// A `PBXFileReference` with `sourceTree: .group` resolves its `path` relative to
+    /// the directory of the group that owns it, which chains up to the directory
+    /// containing the .xcodeproj -- not the MCP server's sandbox basePath. Storing a
+    /// basePath-relative path breaks the reference whenever the owning group carries a
+    /// `path` of its own, because the group's directory then gets applied on top of it.
+    /// This mirrors how `AddFileTool` computes the path when it first adds the file.
+    private func referencePath(
+        for fileRef: PBXFileReference,
+        movedTo resolvedNewPath: String,
+        in pbxproj: PBXProj,
+        projectDirectory: Path
+    ) -> String {
+        let fallback =
+            pathUtility.makeRelativePath(from: resolvedNewPath) ?? resolvedNewPath
+
+        switch fileRef.sourceTree {
+        case .group:
+            // `parent` is not guaranteed to be populated for references decoded from
+            // disk, so locate the owning group by looking for it among the children.
+            let owningGroup =
+                (fileRef.parent as? PBXGroup)
+                ?? pbxproj.groups.first { group in
+                    group.children.contains { $0 === fileRef }
+                }
+            let groupDirectory =
+                owningGroup.flatMap { try? $0.fullPath(sourceRoot: projectDirectory) }
+                ?? projectDirectory
+            return PathUtility.relativePath(from: groupDirectory.string, to: resolvedNewPath)
+                ?? fallback
+        case .sourceRoot:
+            // Resolved relative to the directory containing the .xcodeproj.
+            return PathUtility.relativePath(
+                from: projectDirectory.string, to: resolvedNewPath) ?? fallback
+        default:
+            // Absolute or build-setting-relative trees carry their own semantics; leave
+            // the existing behaviour untouched.
+            return fallback
         }
     }
 }

--- a/Tests/XcodeProjectMCPTests/MoveFileToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/MoveFileToolTests.swift
@@ -180,6 +180,80 @@ struct MoveFileToolTests {
         #expect(content == "// Test file")
     }
 
+    @Test("Move file inside a group keeps the reference resolvable")
+    func moveFileInGroupKeepsReferenceResolvable() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        // The project lives in a subdirectory so that basePath and the project
+        // directory are distinct, and the file sits in a group with its own path.
+        let projectDir = tempDir.appendingPathComponent("App")
+        let sourcesDir = projectDir.appendingPathComponent("Sources")
+        try FileManager.default.createDirectory(at: sourcesDir, withIntermediateDirectories: true)
+
+        let projectPath = Path(projectDir.path) + "TestProject.xcodeproj"
+        try TestProjectHelper.createTestProjectWithTarget(
+            name: "TestProject", targetName: "TestApp", at: projectPath)
+
+        let pathUtility = PathUtility(basePath: tempDir.path)
+
+        // Create a group backed by the Sources directory.
+        let groupTool = CreateGroupTool(pathUtility: pathUtility)
+        _ = try groupTool.execute(
+            arguments: [
+                "project_path": Value.string(projectPath.string),
+                "group_name": Value.string("Sources"),
+                "path": Value.string("Sources"),
+            ] as [String: Value])
+
+        // Add a file into that group.
+        let oldFilePath = sourcesDir.appendingPathComponent("OldFile.swift").path
+        try "// Test file".write(toFile: oldFilePath, atomically: true, encoding: .utf8)
+
+        let addTool = AddFileTool(pathUtility: pathUtility)
+        _ = try addTool.execute(
+            arguments: [
+                "project_path": Value.string(projectPath.string),
+                "file_path": Value.string(oldFilePath),
+                "group_name": Value.string("Sources"),
+                "target_name": Value.string("TestApp"),
+            ] as [String: Value])
+
+        // Move it within the same group.
+        let newFilePath = sourcesDir.appendingPathComponent("NewFile.swift").path
+        let moveTool = MoveFileTool(pathUtility: pathUtility)
+        _ = try moveTool.execute(
+            arguments: [
+                "project_path": Value.string(projectPath.string),
+                "old_path": Value.string(oldFilePath),
+                "new_path": Value.string(newFilePath),
+                "move_on_disk": Value.bool(true),
+            ] as [String: Value])
+
+        let xcodeproj = try XcodeProj(path: projectPath)
+        guard
+            let fileRef = xcodeproj.pbxproj.fileReferences.first(where: {
+                $0.name == "NewFile.swift"
+            })
+        else {
+            Issue.record("Moved file reference not found")
+            return
+        }
+
+        // The path is stored relative to the owning group, not to basePath.
+        #expect(fileRef.path == "NewFile.swift")
+
+        // And it therefore still resolves to the file on disk.
+        let resolved = try fileRef.fullPath(sourceRoot: Path(projectDir.path))
+        #expect(resolved?.string == newFilePath)
+        #expect(FileManager.default.fileExists(atPath: newFilePath) == true)
+    }
+
     @Test("Move non-existent file")
     func moveNonExistentFile() throws {
         // Create a temporary directory


### PR DESCRIPTION
## Problem

`move_file` wrote the new path onto the file reference as a basePath-relative path while leaving `sourceTree` as `.group`. A `PBXFileReference` with that source tree resolves its `path` against the directory of the group that owns it, so whenever that group carries a `path` of its own, the group's directory is applied on top of the stored path and the reference no longer resolves.

Renaming a file inside a group whose path is `Sources`:

```
before move: path = "OldFile.swift"                    ← relative to the group, correct
after move:  path = "App/Sources/NewFile.swift"        ← relative to basePath
resolves to: App/Sources/App/Sources/NewFile.swift     ← the group's directory applied twice
```

The rename on disk succeeds, so nothing looks wrong until the project is opened in Xcode and the file turns up missing.

## Fix

Compute the stored path against the owning group's directory, mirroring how `AddFileTool` already derives it when the file is first added (the same class of bug fixed for `add_file` in 11536b7). `.sourceRoot` references resolve against the directory containing the .xcodeproj, so they are handled explicitly; other source trees carry their own semantics and keep their existing behaviour.

The owning group is located by scanning `children`, because `parent` is not guaranteed to be populated on references decoded from disk.

## Tests

Adds `Move file inside a group keeps the reference resolvable`, which builds the failing shape — project in a subdirectory so basePath and the project directory differ, file in a group with its own path — and asserts both the stored path and that `fullPath(sourceRoot:)` resolves back to the file on disk.

Verified it fails without the fix:

```
Expectation failed: fileRef.path == "NewFile.swift"
  fileRef.path → "App/Sources/NewFile.swift"
Expectation failed: resolved?.string == newFilePath
  resolved?.string → ".../App/Sources/App/Sources/NewFile.swift"
```

Full suite passes with the fix: 171 tests in 23 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ekd6pZytfBcVLerQ1YETcr