### PR TITLE
test: move the remaining suites onto the .temporaryDirectory trait

### DIFF
--- a/Tests/XcodeProjectMCPTests/AddAppExtensionToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddAppExtensionToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("AddAppExtensionTool Tests")
+@Suite("AddAppExtensionTool Tests", .temporaryDirectory)
 struct AddAppExtensionToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -77,14 +77,7 @@ struct AddAppExtensionToolTests {
 
     @Test("Add widget extension")
     func addWidgetExtension() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(
@@ -128,14 +121,7 @@ struct AddAppExtensionToolTests {
 
     @Test("Add notification service extension")
     func addNotificationServiceExtension() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(
@@ -168,14 +154,7 @@ struct AddAppExtensionToolTests {
 
     @Test("Add share extension")
     func addShareExtension() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(
@@ -207,14 +186,7 @@ struct AddAppExtensionToolTests {
 
     @Test("Add extension with deployment target")
     func addExtensionWithDeploymentTarget() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(
@@ -250,14 +222,7 @@ struct AddAppExtensionToolTests {
 
     @Test("Add duplicate extension")
     func addDuplicateExtension() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(
@@ -287,14 +252,7 @@ struct AddAppExtensionToolTests {
 
     @Test("Add extension with non-existent host target")
     func addExtensionWithNonExistentHostTarget() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -319,14 +277,7 @@ struct AddAppExtensionToolTests {
 
     @Test("Add extension with invalid extension type")
     func addExtensionWithInvalidExtensionType() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(
@@ -348,14 +299,7 @@ struct AddAppExtensionToolTests {
 
     @Test("Add extension to non-application target")
     func addExtensionToNonApplicationTarget() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create project with framework target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -390,14 +334,7 @@ struct AddAppExtensionToolTests {
 
     @Test("Add intents extension")
     func addIntentsExtension() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(

--- a/Tests/XcodeProjectMCPTests/AddBuildPhaseToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddBuildPhaseToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("AddBuildPhaseTool Tests")
+@Suite("AddBuildPhaseTool Tests", .temporaryDirectory)
 struct AddBuildPhaseToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -60,14 +60,7 @@ struct AddBuildPhaseToolTests {
 
     @Test("Add run script build phase")
     func addRunScriptBuildPhase() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -112,14 +105,7 @@ struct AddBuildPhaseToolTests {
 
     @Test("Add copy files build phase")
     func addCopyFilesBuildPhase() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -174,14 +160,7 @@ struct AddBuildPhaseToolTests {
 
     @Test("Add run script phase without script")
     func addRunScriptPhaseWithoutScript() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -204,14 +183,7 @@ struct AddBuildPhaseToolTests {
 
     @Test("Add copy files phase without destination")
     func addCopyFilesPhaseWithoutDestination() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -234,14 +206,7 @@ struct AddBuildPhaseToolTests {
 
     @Test("Add build phase with invalid phase type")
     func addBuildPhaseWithInvalidPhaseType() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -263,14 +228,7 @@ struct AddBuildPhaseToolTests {
 
     @Test("Add build phase to non-existent target")
     func addBuildPhaseToNonExistentTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"

--- a/Tests/XcodeProjectMCPTests/AddDependencyToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddDependencyToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("AddDependencyTool Tests")
+@Suite("AddDependencyTool Tests", .temporaryDirectory)
 struct AddDependencyToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -48,14 +48,7 @@ struct AddDependencyToolTests {
 
     @Test("Add dependency between targets")
     func addDependencyBetweenTargets() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -103,14 +96,7 @@ struct AddDependencyToolTests {
 
     @Test("Add duplicate dependency")
     func addDuplicateDependency() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with targets
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -150,14 +136,7 @@ struct AddDependencyToolTests {
 
     @Test("Add dependency with non-existent target")
     func addDependencyWithNonExistentTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -182,14 +161,7 @@ struct AddDependencyToolTests {
 
     @Test("Add dependency with non-existent dependency")
     func addDependencyWithNonExistentDependency() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"

--- a/Tests/XcodeProjectMCPTests/AddFolderToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddFolderToolTests.swift
@@ -6,17 +6,14 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
+@Suite(.temporaryDirectory)
 struct AddFolderToolTests {
     let tempDir: String
     let pathUtility: PathUtility
 
     init() {
-        self.tempDir =
-            FileManager.default.temporaryDirectory
-            .appendingPathComponent("AddFolderToolTests-\(UUID().uuidString)")
-            .path
+        self.tempDir = TemporaryDirectory.url.path
         self.pathUtility = PathUtility(basePath: tempDir)
-        try? FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
     }
 
     @Test("Tool has correct properties")
@@ -194,9 +191,6 @@ struct AddFolderToolTests {
                 "folder_path": .string("/path/that/does/not/exist"),
             ])
         }
-
-        // Clean up
-        try FileManager.default.removeItem(atPath: projectPath.string)
     }
 
     @Test("Fails when path is not a directory")
@@ -219,9 +213,5 @@ struct AddFolderToolTests {
                 "folder_path": .string(filePath.string),
             ])
         }
-
-        // Clean up
-        try FileManager.default.removeItem(atPath: projectPath.string)
-        try FileManager.default.removeItem(atPath: filePath.string)
     }
 }

--- a/Tests/XcodeProjectMCPTests/AddFrameworkToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddFrameworkToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("AddFrameworkTool Tests")
+@Suite("AddFrameworkTool Tests", .temporaryDirectory)
 struct AddFrameworkToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -48,14 +48,7 @@ struct AddFrameworkToolTests {
 
     @Test("Add system framework")
     func addSystemFramework() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -98,14 +91,7 @@ struct AddFrameworkToolTests {
 
     @Test("Add custom framework without embedding")
     func addCustomFrameworkWithoutEmbedding() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -134,14 +120,7 @@ struct AddFrameworkToolTests {
 
     @Test("Add custom framework with embedding")
     func addCustomFrameworkWithEmbedding() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -184,14 +163,7 @@ struct AddFrameworkToolTests {
 
     @Test("Add duplicate framework")
     func addDuplicateFramework() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -221,14 +193,7 @@ struct AddFrameworkToolTests {
 
     @Test("Add framework to non-existent target")
     func addFrameworkToNonExistentTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"

--- a/Tests/XcodeProjectMCPTests/AddSwiftPackageToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddSwiftPackageToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("AddSwiftPackageTool Tests")
+@Suite("AddSwiftPackageTool Tests", .temporaryDirectory)
 struct AddSwiftPackageToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -48,13 +48,7 @@ struct AddSwiftPackageToolTests {
 
     @Test("Add Swift Package with exact version")
     func addSwiftPackageWithExactVersion() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -88,13 +82,7 @@ struct AddSwiftPackageToolTests {
 
     @Test("Add Swift Package with from version")
     func addSwiftPackageWithFromVersion() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -127,13 +115,7 @@ struct AddSwiftPackageToolTests {
 
     @Test("Add Swift Package with branch")
     func addSwiftPackageWithBranch() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -165,13 +147,7 @@ struct AddSwiftPackageToolTests {
 
     @Test("Add Swift Package to specific target")
     func addSwiftPackageToSpecificTarget() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(
@@ -210,13 +186,7 @@ struct AddSwiftPackageToolTests {
 
     @Test("Add duplicate Swift Package")
     func addDuplicateSwiftPackage() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -243,13 +213,7 @@ struct AddSwiftPackageToolTests {
 
     @Test("Add package with invalid target")
     func addPackageWithInvalidTarget() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)

--- a/Tests/XcodeProjectMCPTests/AddTargetToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/AddTargetToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("AddTargetTool Tests")
+@Suite("AddTargetTool Tests", .temporaryDirectory)
 struct AddTargetToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -60,14 +60,7 @@ struct AddTargetToolTests {
 
     @Test("Add application target")
     func addApplicationTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -112,14 +105,7 @@ struct AddTargetToolTests {
 
     @Test("Add framework target")
     func addFrameworkTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -159,14 +145,7 @@ struct AddTargetToolTests {
 
     @Test("Add unit test target")
     func addUnitTestTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -198,14 +177,7 @@ struct AddTargetToolTests {
 
     @Test("Add duplicate target")
     func addDuplicateTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with existing target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -232,14 +204,7 @@ struct AddTargetToolTests {
 
     @Test("Add target with invalid product type")
     func addTargetWithInvalidProductType() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -260,13 +225,7 @@ struct AddTargetToolTests {
 
     @Test("Add static framework target")
     func addStaticFrameworkTarget() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -294,13 +253,7 @@ struct AddTargetToolTests {
 
     @Test("Add XCFramework target")
     func addXCFrameworkTarget() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -328,13 +281,7 @@ struct AddTargetToolTests {
 
     @Test("Add app extension target")
     func addAppExtensionTarget() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -362,13 +309,7 @@ struct AddTargetToolTests {
 
     @Test("Add command line tool target")
     func addCommandLineToolTarget() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -397,13 +338,7 @@ struct AddTargetToolTests {
 
     @Test("Add watch app target")
     func addWatchAppTarget() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -432,13 +367,7 @@ struct AddTargetToolTests {
 
     @Test("Add messages extension target")
     func addMessagesExtensionTarget() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -466,13 +395,7 @@ struct AddTargetToolTests {
 
     @Test("Add xpc service target")
     func addXPCServiceTarget() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)

--- a/Tests/XcodeProjectMCPTests/CreateGroupToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/CreateGroupToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("CreateGroupTool Tests")
+@Suite("CreateGroupTool Tests", .temporaryDirectory)
 struct CreateGroupToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -38,14 +38,7 @@ struct CreateGroupToolTests {
 
     @Test("Create group in main group")
     func createGroupInMainGroup() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -76,14 +69,7 @@ struct CreateGroupToolTests {
 
     @Test("Create group with path")
     func createGroupWithPath() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -115,14 +101,7 @@ struct CreateGroupToolTests {
 
     @Test("Create group in parent group")
     func createGroupInParentGroup() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -170,14 +149,7 @@ struct CreateGroupToolTests {
 
     @Test("Create duplicate group")
     func createDuplicateGroup() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -205,13 +177,7 @@ struct CreateGroupToolTests {
 
     @Test("Create group in nested parent group using hierarchical path")
     func createGroupInNestedParentGroup() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithNestedGroups(
@@ -246,14 +212,7 @@ struct CreateGroupToolTests {
 
     @Test("Create group with non-existent parent")
     func createGroupWithNonExistentParent() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"

--- a/Tests/XcodeProjectMCPTests/DuplicateTargetToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/DuplicateTargetToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("DuplicateTargetTool Tests")
+@Suite("DuplicateTargetTool Tests", .temporaryDirectory)
 struct DuplicateTargetToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -48,14 +48,7 @@ struct DuplicateTargetToolTests {
 
     @Test("Duplicate existing target")
     func duplicateExistingTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -94,14 +87,7 @@ struct DuplicateTargetToolTests {
 
     @Test("Duplicate target with new bundle identifier")
     func duplicateTargetWithNewBundleIdentifier() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -138,14 +124,7 @@ struct DuplicateTargetToolTests {
 
     @Test("Duplicate non-existent target")
     func duplicateNonExistentTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -170,14 +149,7 @@ struct DuplicateTargetToolTests {
 
     @Test("Duplicate to existing target name")
     func duplicateToExistingTargetName() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -213,14 +185,7 @@ struct DuplicateTargetToolTests {
 
     @Test("Duplicate target with dependencies")
     func duplicateTargetWithDependencies() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with targets
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"

--- a/Tests/XcodeProjectMCPTests/GetBuildSettingsToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/GetBuildSettingsToolTests.swift
@@ -6,6 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
+@Suite(.temporaryDirectory)
 struct GetBuildSettingsToolTests {
 
     @Test func testGetBuildSettingsToolCreation() {
@@ -48,16 +49,9 @@ struct GetBuildSettingsToolTests {
     }
 
     @Test func testGetBuildSettingsWithNonexistentTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let tempDir = TemporaryDirectory.url
 
         let tool = GetBuildSettingsTool(pathUtility: PathUtility(basePath: tempDir.path))
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
 
         // Create a test project using XcodeProj
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -75,16 +69,9 @@ struct GetBuildSettingsToolTests {
     }
 
     @Test func testGetBuildSettingsWithValidTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let tempDir = TemporaryDirectory.url
 
         let tool = GetBuildSettingsTool(pathUtility: PathUtility(basePath: tempDir.path))
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
 
         // Create a test project with a target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -109,16 +96,9 @@ struct GetBuildSettingsToolTests {
     }
 
     @Test func testGetBuildSettingsWithSpecificConfiguration() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let tempDir = TemporaryDirectory.url
 
         let tool = GetBuildSettingsTool(pathUtility: PathUtility(basePath: tempDir.path))
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
 
         // Create a test project with a target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"

--- a/Tests/XcodeProjectMCPTests/ListBuildConfigurationsToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/ListBuildConfigurationsToolTests.swift
@@ -6,6 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
+@Suite(.temporaryDirectory)
 struct ListBuildConfigurationsToolTests {
 
     @Test func testListBuildConfigurationsToolCreation() {
@@ -36,16 +37,9 @@ struct ListBuildConfigurationsToolTests {
     }
 
     @Test func testListBuildConfigurationsWithValidProject() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let tempDir = TemporaryDirectory.url
 
         let tool = ListBuildConfigurationsTool(pathUtility: PathUtility(basePath: tempDir.path))
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
 
         // Create a test project using XcodeProj
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"

--- a/Tests/XcodeProjectMCPTests/ListFilesToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/ListFilesToolTests.swift
@@ -6,6 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
+@Suite(.temporaryDirectory)
 struct ListFilesToolTests {
 
     @Test func testListFilesToolCreation() {
@@ -42,16 +43,9 @@ struct ListFilesToolTests {
     }
 
     @Test func testListFilesWithEmptyTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let tempDir = TemporaryDirectory.url
 
         let tool = ListFilesTool(pathUtility: PathUtility(basePath: tempDir.path))
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
 
         // Create a test project with target using XcodeProj
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -76,16 +70,9 @@ struct ListFilesToolTests {
     }
 
     @Test func testListFilesWithInvalidTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let tempDir = TemporaryDirectory.url
 
         let tool = ListFilesTool(pathUtility: PathUtility(basePath: tempDir.path))
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
 
         // Create a test project with target using XcodeProj
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -104,16 +91,9 @@ struct ListFilesToolTests {
     }
 
     @Test func testListFilesWithSourceFiles() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let tempDir = TemporaryDirectory.url
 
         let tool = ListFilesTool(pathUtility: PathUtility(basePath: tempDir.path))
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
 
         // Create a test project with target using XcodeProj
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"

--- a/Tests/XcodeProjectMCPTests/ListGroupsToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/ListGroupsToolTests.swift
@@ -6,17 +6,14 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
+@Suite(.temporaryDirectory)
 struct ListGroupsToolTests {
     let tempDir: String
     let pathUtility: PathUtility
 
     init() {
-        self.tempDir =
-            FileManager.default.temporaryDirectory
-            .appendingPathComponent("ListGroupsToolTests-\(UUID().uuidString)")
-            .path
+        self.tempDir = TemporaryDirectory.url.path
         self.pathUtility = PathUtility(basePath: tempDir)
-        try? FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
     }
 
     @Test("Tool has correct properties")
@@ -240,5 +237,4 @@ struct ListGroupsToolTests {
             Issue.record("Expected text result")
         }
     }
-
 }

--- a/Tests/XcodeProjectMCPTests/ListSwiftPackagesToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/ListSwiftPackagesToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("ListSwiftPackagesTool Tests")
+@Suite("ListSwiftPackagesTool Tests", .temporaryDirectory)
 struct ListSwiftPackagesToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -29,13 +29,7 @@ struct ListSwiftPackagesToolTests {
 
     @Test("List packages from empty project")
     func listPackagesFromEmptyProject() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -56,13 +50,7 @@ struct ListSwiftPackagesToolTests {
 
     @Test("List packages with remote packages")
     func listPackagesWithRemotePackages() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -115,13 +103,7 @@ struct ListSwiftPackagesToolTests {
 
     @Test("List packages with local packages")
     func listPackagesWithLocalPackages() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -158,13 +140,7 @@ struct ListSwiftPackagesToolTests {
 
     @Test("List packages with mixed remote and local packages")
     func listPackagesWithMixedPackages() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)

--- a/Tests/XcodeProjectMCPTests/ListTargetsToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/ListTargetsToolTests.swift
@@ -6,6 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
+@Suite(.temporaryDirectory)
 struct ListTargetsToolTests {
 
     @Test func testListTargetsToolCreation() {
@@ -36,16 +37,9 @@ struct ListTargetsToolTests {
     }
 
     @Test func testListTargetsWithEmptyProject() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let tempDir = TemporaryDirectory.url
 
         let tool = ListTargetsTool(pathUtility: PathUtility(basePath: tempDir.path))
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
 
         // Create a test project using XcodeProj
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"

--- a/Tests/XcodeProjectMCPTests/MoveFileToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/MoveFileToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("MoveFileTool Tests")
+@Suite("MoveFileTool Tests", .temporaryDirectory)
 struct MoveFileToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -58,14 +58,7 @@ struct MoveFileToolTests {
 
     @Test("Move file in project")
     func moveFile() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -126,14 +119,7 @@ struct MoveFileToolTests {
 
     @Test("Move file on disk")
     func moveFileOnDisk() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -182,13 +168,7 @@ struct MoveFileToolTests {
 
     @Test("Move file inside a group keeps the reference resolvable")
     func moveFileInGroupKeepsReferenceResolvable() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // The project lives in a subdirectory so that basePath and the project
         // directory are distinct, and the file sits in a group with its own path.
@@ -256,14 +236,7 @@ struct MoveFileToolTests {
 
     @Test("Move non-existent file")
     func moveNonExistentFile() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"

--- a/Tests/XcodeProjectMCPTests/PathUtilityTests.swift
+++ b/Tests/XcodeProjectMCPTests/PathUtilityTests.swift
@@ -3,6 +3,7 @@ import Testing
 
 @testable import XcodeProjectMCP
 
+@Suite(.temporaryDirectory)
 struct PathUtilityTests {
 
     @Test func testRelativePathResolution() throws {
@@ -49,16 +50,9 @@ struct PathUtilityTests {
     }
 
     @Test func testDotDotPathResolution() throws {
-        // Create a temporary subdirectory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let tempDir = TemporaryDirectory.url
         let basePath = tempDir.appendingPathComponent("projects").path
         try FileManager.default.createDirectory(atPath: basePath, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
 
         let pathUtility = PathUtility(basePath: basePath)
 

--- a/Tests/XcodeProjectMCPTests/RemoveAppExtensionToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/RemoveAppExtensionToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("RemoveAppExtensionTool Tests")
+@Suite("RemoveAppExtensionTool Tests", .temporaryDirectory)
 struct RemoveAppExtensionToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -41,14 +41,7 @@ struct RemoveAppExtensionToolTests {
 
     @Test("Remove widget extension")
     func removeWidgetExtension() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(
@@ -93,14 +86,7 @@ struct RemoveAppExtensionToolTests {
 
     @Test("Remove non-existent extension")
     func removeNonExistentExtension() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(
@@ -121,14 +107,7 @@ struct RemoveAppExtensionToolTests {
 
     @Test("Remove non-extension target fails")
     func removeNonExtensionTargetFails() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(
@@ -149,14 +128,7 @@ struct RemoveAppExtensionToolTests {
 
     @Test("Remove extension cleans up embed phase")
     func removeExtensionCleansUpEmbedPhase() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(
@@ -193,14 +165,7 @@ struct RemoveAppExtensionToolTests {
 
     @Test("Remove multiple extensions")
     func removeMultipleExtensions() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appending(
-            component:
-                UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(

--- a/Tests/XcodeProjectMCPTests/RemoveFileToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/RemoveFileToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("RemoveFileTool Tests")
+@Suite("RemoveFileTool Tests", .temporaryDirectory)
 struct RemoveFileToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -38,14 +38,7 @@ struct RemoveFileToolTests {
 
     @Test("Remove file from project")
     func removeFile() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -103,14 +96,7 @@ struct RemoveFileToolTests {
 
     @Test("Remove file from disk")
     func removeFileFromDisk() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -150,14 +136,7 @@ struct RemoveFileToolTests {
 
     @Test("Remove non-existent file")
     func removeNonExistentFile() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"

--- a/Tests/XcodeProjectMCPTests/RemoveSwiftPackageToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/RemoveSwiftPackageToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("RemoveSwiftPackageTool Tests")
+@Suite("RemoveSwiftPackageTool Tests", .temporaryDirectory)
 struct RemoveSwiftPackageToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -39,13 +39,7 @@ struct RemoveSwiftPackageToolTests {
 
     @Test("Remove non-existent package")
     func removeNonExistentPackage() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -67,13 +61,7 @@ struct RemoveSwiftPackageToolTests {
 
     @Test("Remove existing package from project")
     func removeExistingPackageFromProject() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)
@@ -115,13 +103,7 @@ struct RemoveSwiftPackageToolTests {
 
     @Test("Remove package from project and targets")
     func removePackageFromProjectAndTargets() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(
@@ -173,13 +155,7 @@ struct RemoveSwiftPackageToolTests {
 
     @Test("Remove package but keep target dependencies")
     func removePackageButKeepTargetDependencies() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProjectWithTarget(
@@ -226,13 +202,7 @@ struct RemoveSwiftPackageToolTests {
 
     @Test("Remove multiple packages")
     func removeMultiplePackages() throws {
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
         try TestProjectHelper.createTestProject(name: "TestProject", at: projectPath)

--- a/Tests/XcodeProjectMCPTests/RemoveTargetToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/RemoveTargetToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("RemoveTargetTool Tests")
+@Suite("RemoveTargetTool Tests", .temporaryDirectory)
 struct RemoveTargetToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -38,14 +38,7 @@ struct RemoveTargetToolTests {
 
     @Test("Remove existing target")
     func removeExistingTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -81,14 +74,7 @@ struct RemoveTargetToolTests {
 
     @Test("Remove non-existent target")
     func removeNonExistentTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -112,14 +98,7 @@ struct RemoveTargetToolTests {
 
     @Test("Remove target with dependencies")
     func removeTargetWithDependencies() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"

--- a/Tests/XcodeProjectMCPTests/SetBuildSettingToolTests.swift
+++ b/Tests/XcodeProjectMCPTests/SetBuildSettingToolTests.swift
@@ -6,7 +6,7 @@ import XcodeProj
 
 @testable import XcodeProjectMCP
 
-@Suite("SetBuildSettingTool Tests")
+@Suite("SetBuildSettingTool Tests", .temporaryDirectory)
 struct SetBuildSettingToolTests {
     @Test("Tool creation")
     func toolCreation() {
@@ -74,14 +74,7 @@ struct SetBuildSettingToolTests {
 
     @Test("Set build setting for specific configuration")
     func setBuildSettingForSpecificConfiguration() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -125,14 +118,7 @@ struct SetBuildSettingToolTests {
 
     @Test("Set build setting for all configurations")
     func setBuildSettingForAllConfigurations() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -176,14 +162,7 @@ struct SetBuildSettingToolTests {
 
     @Test("Set build setting with non-existent target")
     func setBuildSettingWithNonExistentTarget() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"
@@ -210,14 +189,7 @@ struct SetBuildSettingToolTests {
 
     @Test("Set build setting with non-existent configuration")
     func setBuildSettingWithNonExistentConfiguration() throws {
-        // Create a temporary directory
-        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(
-            UUID().uuidString)
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-
-        defer {
-            try? FileManager.default.removeItem(at: tempDir)
-        }
+        let tempDir = TemporaryDirectory.url
 
         // Create a test project with target
         let projectPath = Path(tempDir.path) + "TestProject.xcodeproj"


### PR DESCRIPTION
Follow-up to #22, which introduced the `.temporaryDirectory` testing trait and used it in `AddFileToolTests`. This applies it to the remaining suites.

Every suite that touches disk carried the same boilerplate:

```swift
let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
defer { try? FileManager.default.removeItem(at: tempDir) }
```

which becomes:

```swift
let tempDir = TemporaryDirectory.url
```

`ListGroupsToolTests` and `AddFolderToolTests` kept their directory in a stored property built in `init()`, so they now read it from the trait instead. Both created a directory per test and never removed it, so this also stops them leaking into `$TMPDIR`. Their two per-test `// Clean up` calls are gone as well, since the whole directory is now removed for them.

Mechanical change otherwise: 22 files, -729/+114 lines, no test bodies or assertions touched.

## Verification

- `swift test` — 173 tests in 23 suites passed
- `swift format lint -r .` — clean
- UUID-named directories in `$TMPDIR`: 0 before the run, 0 after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ekd6pZytfBcVLerQ1YETcr